### PR TITLE
🐛reuse kubectl found in path

### DIFF
--- a/pkg/kwokctl/runtime/cluster.go
+++ b/pkg/kwokctl/runtime/cluster.go
@@ -193,12 +193,16 @@ func (c *Cluster) KubectlInCluster(ctx context.Context, stm utils.IOStreams, arg
 		return err
 	}
 
-	bin := utils.PathJoin(conf.Workdir, "bin")
-	kubectlPath := utils.PathJoin(bin, "kubectl"+vars.BinSuffix)
-	err = utils.DownloadWithCache(ctx, conf.CacheDir, vars.MustKubectlBinary, kubectlPath, 0755, conf.QuietPull)
+	kubectlPath, err := exec.LookPath("kubectl")
 	if err != nil {
-		return err
+		bin := utils.PathJoin(conf.Workdir, "bin")
+		kubectlPath := utils.PathJoin(bin, "kubectl"+vars.BinSuffix)
+		err = utils.DownloadWithCache(ctx, conf.CacheDir, vars.MustKubectlBinary, kubectlPath, 0755, conf.QuietPull)
+		if err != nil {
+			return err
+		}
 	}
+
 	return utils.Exec(ctx, "", stm, kubectlPath,
 		append([]string{"--kubeconfig", utils.PathJoin(conf.Workdir, InHostKubeconfigName)}, args...)...)
 }


### PR DESCRIPTION
In my M1 env, I'd like to reuse the `kubectl`; otherwise you cannot download a darwin/arm64 kubectl binary:

w/o this PR, the following command won't work in M1:

```
KWOK_KUBE_VERSION=v1.20.15 kwokctl create cluster --runtime binary --kube-scheduler-binary /usr/local/bin/kube-scheduler@1.20.15 --kube-controller-manager-binary /usr/local/bin/kube-controller-manager@1.20.15  --kube-apiserver-binary /usr/local/bin/kube-apiserver@1.20.15 --kwok-controller-binary /usr/local/bin/kwok --etcd-binary /opt/homebrew/bin/etcd --name 120-binary
```