### PR TITLE
Support enable audit log

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -127,6 +127,11 @@ jobs:
         run: |
           ./hack/e2e-test.sh kwokctl/kwokctl_${{ matrix.kwokctl-runtime }}_snapshot
 
+      - name: Test Audit
+        shell: bash
+        run: |
+          ./hack/e2e-test.sh kwokctl/kwokctl_${{ matrix.kwokctl-runtime }}_audit
+
       - name: Test Benchmark
         shell: bash
         if: ${{ matrix.kwokctl-runtime != 'kind' }}

--- a/pkg/kwokctl/cmd/create/cluster/cluster.go
+++ b/pkg/kwokctl/cmd/create/cluster/cluster.go
@@ -54,6 +54,7 @@ type flagpole struct {
 	Runtime                     string
 	KubeFeatureGates            string
 	KubeRuntimeConfig           string
+	KubeAuditPolicy             string
 	Timeout                     time.Duration
 }
 
@@ -113,6 +114,7 @@ func NewCommand(logger logger.Logger) *cobra.Command {
 `)
 	cmd.Flags().StringVar(&flags.KubeRuntimeConfig, "kube-runtime-config", vars.KubeRuntimeConfig, `A set of key=value pairs that enable or disable built-in APIs
 `)
+	cmd.Flags().StringVar(&flags.KubeAuditPolicy, "kube-audit-policy", vars.KubeAuditPolicy, "Path to the file that defines the audit policy configuration")
 	cmd.Flags().StringVar(&flags.Runtime, "runtime", vars.Runtime, fmt.Sprintf("Runtime of the cluster (%s)", strings.Join(runtime.DefaultRegistry.List(), " or ")))
 	cmd.Flags().DurationVar(&flags.Timeout, "timeout", 30*time.Second, "Timeout for waiting for the cluster to be ready")
 	return cmd
@@ -181,6 +183,7 @@ func runE(ctx context.Context, logger logger.Logger, flags *flagpole) error {
 			PrometheusPort:              flags.PrometheusPort,
 			FeatureGates:                flags.KubeFeatureGates,
 			RuntimeConfig:               flags.KubeRuntimeConfig,
+			AuditPolicy:                 flags.KubeAuditPolicy,
 		})
 		if err != nil {
 			logger.Printf("Failed to setup config %q: %v", name, err)

--- a/pkg/kwokctl/cmd/logs/logs.go
+++ b/pkg/kwokctl/cmd/logs/logs.go
@@ -40,8 +40,8 @@ func NewCommand(logger logger.Logger) *cobra.Command {
 	cmd := &cobra.Command{
 		Args:  cobra.ExactArgs(1),
 		Use:   "logs",
-		Short: "Logs one of [etcd, kube-apiserver, kube-controller-manager, kube-scheduler, kwok-controller, prometheus]",
-		Long:  "Logs one of [etcd, kube-apiserver, kube-controller-manager, kube-scheduler, kwok-controller, prometheus]",
+		Short: "Logs one of [audit, etcd, kube-apiserver, kube-controller-manager, kube-scheduler, kwok-controller, prometheus]",
+		Long:  "Logs one of [audit, etcd, kube-apiserver, kube-controller-manager, kube-scheduler, kwok-controller, prometheus]",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			flags.Name = vars.DefaultCluster
 			return runE(cmd.Context(), logger, flags, args)
@@ -60,10 +60,18 @@ func runE(ctx context.Context, logger logger.Logger, flags *flagpole, args []str
 		return err
 	}
 
-	if flags.Follow {
-		err = rt.LogsFollow(ctx, args[0], os.Stdout)
+	if args[0] == "audit" {
+		if flags.Follow {
+			err = rt.AuditLogsFollow(ctx, os.Stdout)
+		} else {
+			err = rt.AuditLogs(ctx, os.Stdout)
+		}
 	} else {
-		err = rt.Logs(ctx, args[0], os.Stdout)
+		if flags.Follow {
+			err = rt.LogsFollow(ctx, args[0], os.Stdout)
+		} else {
+			err = rt.Logs(ctx, args[0], os.Stdout)
+		}
 	}
 	if err != nil {
 		return err

--- a/pkg/kwokctl/runtime/compose/cluster.go
+++ b/pkg/kwokctl/runtime/compose/cluster.go
@@ -51,6 +51,21 @@ func (c *Cluster) Install(ctx context.Context) error {
 	inClusterOnHostKubeconfigPath := utils.PathJoin(conf.Workdir, runtime.InClusterKubeconfigName)
 	pkiPath := utils.PathJoin(conf.Workdir, runtime.PkiName)
 	composePath := utils.PathJoin(conf.Workdir, runtime.ComposeName)
+	auditLogPath := ""
+	auditPolicyPath := ""
+	if conf.AuditPolicy != "" {
+		auditLogPath = utils.PathJoin(conf.Workdir, "logs", runtime.AuditLogName)
+		err = utils.CreateFile(auditLogPath, 0644)
+		if err != nil {
+			return err
+		}
+
+		auditPolicyPath = utils.PathJoin(conf.Workdir, runtime.AuditPolicyName)
+		err = utils.CopyFile(conf.AuditPolicy, auditPolicyPath)
+		if err != nil {
+			return err
+		}
+	}
 
 	caCertPath := ""
 	adminKeyPath := ""
@@ -133,6 +148,8 @@ func (c *Cluster) Install(ctx context.Context) error {
 		PrometheusPort:             conf.PrometheusPort,
 		RuntimeConfig:              conf.RuntimeConfig,
 		FeatureGates:               conf.FeatureGates,
+		AuditPolicy:                auditPolicyPath,
+		AuditLog:                   auditLogPath,
 	})
 	if err != nil {
 		return err

--- a/pkg/kwokctl/runtime/compose/compose.go
+++ b/pkg/kwokctl/runtime/compose/compose.go
@@ -67,4 +67,7 @@ type BuildComposeConfig struct {
 
 	RuntimeConfig string
 	FeatureGates  string
+
+	AuditPolicy string
+	AuditLog    string
 }

--- a/pkg/kwokctl/runtime/compose/compose.yaml.tpl
+++ b/pkg/kwokctl/runtime/compose/compose.yaml.tpl
@@ -83,13 +83,26 @@ services:
       - "8080"
 {{ end }}
 
-{{ if .SecretPort }}
+{{ if .AuditPolicy }}
+      - --audit-policy-file
+      - /etc/kubernetes/audit-policy.yaml
+      - --audit-log-path
+      - /var/log/kubernetes/audit/audit.log
+{{ end }}
+
+{{ if or .SecretPort .AuditPolicy }}
     volumes:
+{{ end }}
+
+{{ if .SecretPort }}
       - {{ .AdminKeyPath }}:{{ .InClusterAdminKeyPath }}:ro
       - {{ .AdminCertPath }}:{{ .InClusterAdminCertPath }}:ro
       - {{ .CACertPath }}:{{ .InClusterCACertPath }}:ro
 {{ end }}
-
+{{ if .AuditPolicy }}
+      - {{ .AuditPolicy }}:/etc/kubernetes/audit-policy.yaml:ro
+      - {{ .AuditLog }}:/var/log/kubernetes/audit/audit.log:rw
+{{ end }}
 
   # Kube-controller-manager
   kube_controller_manager:

--- a/pkg/kwokctl/runtime/config.go
+++ b/pkg/kwokctl/runtime/config.go
@@ -69,6 +69,9 @@ type Config struct {
 	// Feature gates of Kubernetes
 	FeatureGates string `json:"kube_feature_gates,omitempty"`
 
+	// For audit log
+	AuditPolicy string `json:"audit_policy,omitempty"`
+
 	// Runtime config of Kubernetes
 	RuntimeConfig string `json:"kube_runtime_config,omitempty"`
 }
@@ -118,6 +121,12 @@ type Runtime interface {
 
 	// LogsFollow follow logs of a component with follow
 	LogsFollow(ctx context.Context, name string, out io.Writer) error
+
+	// AuditLogs audit logs of apiserver
+	AuditLogs(ctx context.Context, out io.Writer) error
+
+	// AuditLogsFollow follow audit logs of apiserver
+	AuditLogsFollow(ctx context.Context, out io.Writer) error
 
 	// ListBinaries list binaries in the cluster
 	ListBinaries(ctx context.Context, actual bool) ([]string, error)

--- a/pkg/kwokctl/runtime/kind/cluster.go
+++ b/pkg/kwokctl/runtime/kind/cluster.go
@@ -55,11 +55,30 @@ func (c *Cluster) Install(ctx context.Context) error {
 	if conf.RuntimeConfig != "" {
 		runtimeConfig = strings.Split(strings.ReplaceAll(conf.RuntimeConfig, "=", ": "), ",")
 	}
+
+	auditLogPath := ""
+	auditPolicyPath := ""
+	if conf.AuditPolicy != "" {
+		auditLogPath = utils.PathJoin(conf.Workdir, "logs", runtime.AuditLogName)
+		err = utils.CreateFile(auditLogPath, 0644)
+		if err != nil {
+			return err
+		}
+
+		auditPolicyPath = utils.PathJoin(conf.Workdir, runtime.AuditPolicyName)
+		err = utils.CopyFile(conf.AuditPolicy, auditPolicyPath)
+		if err != nil {
+			return err
+		}
+	}
+
 	kindYaml, err := BuildKind(BuildKindConfig{
 		KubeApiserverPort: conf.KubeApiserverPort,
 		PrometheusPort:    conf.PrometheusPort,
 		FeatureGates:      featureGates,
 		RuntimeConfig:     runtimeConfig,
+		AuditPolicy:       auditPolicyPath,
+		AuditLog:          auditLogPath,
 	})
 	if err != nil {
 		return err

--- a/pkg/kwokctl/runtime/kind/kind.yaml.tpl
+++ b/pkg/kwokctl/runtime/kind/kind.yaml.tpl
@@ -7,14 +7,45 @@ networking:
   apiServerPort: {{ .KubeApiserverPort }}
 {{ end }}
 nodes:
-  - role: control-plane
+- role: control-plane
 
 {{ if .PrometheusPort }}
-    extraPortMappings:
-      - containerPort: 9090
-        hostPort: {{ .PrometheusPort }}
-        listenAddress: "0.0.0.0"
-        protocol: TCP
+  extraPortMappings:
+  - containerPort: 9090
+    hostPort: {{ .PrometheusPort }}
+    listenAddress: "0.0.0.0"
+    protocol: TCP
+{{ end }}
+
+{{ if .AuditPolicy }}
+  kubeadmConfigPatches:
+  - |
+    kind: ClusterConfiguration
+    apiServer:
+      # enable auditing flags on the API server
+      extraArgs:
+        audit-log-path: /var/log/kubernetes/audit.log
+        audit-policy-file: /etc/kubernetes/audit/audit.yaml
+      # mount new files / directories on the control plane
+      extraVolumes:
+      - name: audit-policies
+        hostPath: /etc/kubernetes/audit
+        mountPath: /etc/kubernetes/audit
+        readOnly: true
+        pathType: "DirectoryOrCreate"
+      - name: "audit-logs"
+        hostPath: "/var/log/kubernetes"
+        mountPath: "/var/log/kubernetes"
+        readOnly: false
+        pathType: DirectoryOrCreate
+  # mount the local file on the control plane
+  extraMounts:
+  - hostPath: {{ .AuditPolicy }}
+    containerPath: /etc/kubernetes/audit/audit.yaml
+    readOnly: true
+  - hostPath: {{ .AuditLog }}
+    containerPath: /var/log/kubernetes/audit.log
+    readOnly: false
 {{ end }}
 
 {{ if .FeatureGates }}

--- a/pkg/kwokctl/utils/file.go
+++ b/pkg/kwokctl/utils/file.go
@@ -14,36 +14,42 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package kind
+package utils
 
 import (
-	"bytes"
-	_ "embed"
-	"fmt"
-	"text/template"
+	"os"
+	"path/filepath"
 )
 
-//go:embed kind.yaml.tpl
-var kindYamlTpl string
-
-var kindYamlTemplate = template.Must(template.New("_").Parse(kindYamlTpl))
-
-func BuildKind(conf BuildKindConfig) (string, error) {
-	buf := bytes.NewBuffer(nil)
-	err := kindYamlTemplate.Execute(buf, conf)
+func CreateFile(name string, perm os.FileMode) error {
+	err := os.MkdirAll(filepath.Dir(name), 0755)
 	if err != nil {
-		return "", fmt.Errorf("failed to execute kind yaml template: %w", err)
+		return err
 	}
-	return buf.String(), nil
+	file, err := os.OpenFile(name, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, perm)
+	if err != nil {
+		return err
+	}
+	file.Close()
+	return nil
 }
 
-type BuildKindConfig struct {
-	KubeApiserverPort uint32
-	PrometheusPort    uint32
+func CopyFile(oldpath, newpath string) error {
 
-	RuntimeConfig []string
-	FeatureGates  []string
+	err := os.MkdirAll(filepath.Dir(newpath), 0755)
+	if err != nil {
+		return err
+	}
 
-	AuditPolicy string
-	AuditLog    string
+	data, err := os.ReadFile(oldpath)
+	if err != nil {
+		return err
+	}
+
+	err = os.WriteFile(newpath, data, 0644)
+	if err != nil {
+		return err
+	}
+
+	return nil
 }

--- a/pkg/kwokctl/vars/vars.go
+++ b/pkg/kwokctl/vars/vars.go
@@ -193,6 +193,9 @@ var (
 		}
 		return ""
 	}())
+
+	// KubeAuditPolicy is path to the file that defines the audit policy configuration
+	KubeAuditPolicy = getEnv("KWOK_KUBE_AUDIT_POLICY", "")
 )
 
 // getEnv returns the value of the environment variable named by the key.

--- a/test/kwokctl/audit-policy.yaml
+++ b/test/kwokctl/audit-policy.yaml
@@ -1,0 +1,4 @@
+apiVersion: audit.k8s.io/v1
+kind: Policy
+rules:
+- level: Metadata

--- a/test/kwokctl/kwokctl_audit_test.sh
+++ b/test/kwokctl/kwokctl_audit_test.sh
@@ -1,0 +1,90 @@
+#!/usr/bin/env bash
+# Copyright 2022 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+DIR="$(dirname "${BASH_SOURCE[0]}")"
+
+DIR="$(realpath "${DIR}")"
+
+RELEASES=()
+
+function usage() {
+  echo "Usage: $0 <kube-version...>"
+  echo "  <kube-version> is the version of kubernetes to test against."
+}
+
+function args() {
+  if [[ $# -eq 0 ]]; then
+    usage
+    exit 1
+  fi
+  while [[ $# -gt 0 ]]; do
+    RELEASES+=("${1}")
+    shift
+  done
+}
+
+function test_create_cluster() {
+  local release="${1}"
+  local name="${2}"
+
+  KWOK_KUBE_VERSION="${release}" kwokctl create cluster --name "${name}" --quiet-pull --kube-audit-policy="${DIR}/audit-policy.yaml"
+  if [[ $? -ne 0 ]]; then
+    echo "Error: Cluster ${name} creation failed"
+    exit 1
+  fi
+}
+
+function test_delete_cluster() {
+  local release="${1}"
+  local name="${2}"
+  kwokctl delete cluster --name "${name}"
+}
+
+function test_audit() {
+  local release="${1}"
+  local name="${2}"
+  local logs
+  logs="$(kwokctl logs --name "${name}" audit)"
+  if [[ "${logs}" == "" ]]; then
+    echo "Error: Audit log is empty"
+    return 1
+  fi
+  echo "${logs}" | head -n 100
+}
+
+function main() {
+  local failed=()
+  for release in "${RELEASES[@]}"; do
+    echo "------------------------------"
+    echo "Testing audit on ${KWOK_RUNTIME} for ${release}"
+    name="audit-cluster-${KWOK_RUNTIME}-${release//./-}"
+    test_create_cluster "${release}" "${name}" || failed+=("create_cluster_${name}")
+    test_audit "${release}" "${name}" || failed+=("audit_${name}")
+    test_delete_cluster "${release}" "${name}" || failed+=("delete_cluster_${name}")
+  done
+
+  if [[ "${#failed[@]}" -ne 0 ]]; then
+    echo "------------------------------"
+    echo "Error: Some tests failed"
+    for test in "${failed[@]}"; do
+      echo " - ${test}"
+    done
+    exit 1
+  fi
+}
+
+args "$@"
+
+main

--- a/test/kwokctl/kwokctl_binary_audit.test.sh
+++ b/test/kwokctl/kwokctl_binary_audit.test.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+# Copyright 2022 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+DIR="$(dirname "${BASH_SOURCE[0]}")"
+
+DIR="$(realpath "${DIR}")"
+
+ROOT_DIR="$(realpath "${DIR}/../..")"
+
+source "${DIR}/helper.sh"
+source "${ROOT_DIR}/hack/requirements.sh"
+
+function requirements() {
+  install_kubectl
+}
+
+function main() {
+  local all_releases=("${@}")
+  build_kwokctl
+  build_kwok
+
+  test_all "binary" "audit" "${all_releases[@]}" || exit 1
+}
+
+requirements
+
+main $(supported_releases)

--- a/test/kwokctl/kwokctl_docker_audit.test.sh
+++ b/test/kwokctl/kwokctl_docker_audit.test.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+# Copyright 2022 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+DIR="$(dirname "${BASH_SOURCE[0]}")"
+
+DIR="$(realpath "${DIR}")"
+
+ROOT_DIR="$(realpath "${DIR}/../..")"
+
+source "${DIR}/helper.sh"
+source "${ROOT_DIR}/hack/requirements.sh"
+
+function requirements() {
+  install_kubectl
+  install_buildx
+  install_compose
+}
+
+function main() {
+  local all_releases=("${@}")
+  build_kwokctl
+  build_image
+
+  test_all "docker" "audit" "${all_releases[@]}" || exit 1
+}
+
+requirements
+
+main $(supported_releases)

--- a/test/kwokctl/kwokctl_kind_audit.test.sh
+++ b/test/kwokctl/kwokctl_kind_audit.test.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+# Copyright 2022 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+DIR="$(dirname "${BASH_SOURCE[0]}")"
+
+DIR="$(realpath "${DIR}")"
+
+ROOT_DIR="$(realpath "${DIR}/../..")"
+
+source "${DIR}/helper.sh"
+source "${ROOT_DIR}/hack/requirements.sh"
+
+function requirements() {
+  install_kubectl
+  install_buildx
+  install_kind
+}
+
+function main() {
+  local all_releases=("${@}")
+  build_kwokctl
+  build_image
+
+  test_all "kind" "audit" "${all_releases[0]}" || exit 1
+}
+
+requirements
+
+main $(supported_releases)


### PR DESCRIPTION
/kind feature
Fixes #39


audit-policy.yaml https://kubernetes.io/docs/tasks/debug/debug-cluster/audit/#audit-policy

Add a flag `--kube-audit-policy` to `kwokctl create cluster` to specify the configuration of the audit policy
``` bash
# Enable audit log
kwokctl create cluster --kube-audit-policy="audit-policy.yaml"
```

Add subcommand `audit` for `kwokctl logs` to export audit logs
``` bash
# Output audit log
kwokctl logs audit
```
