### PR TITLE
add comment note for node-label-selector filter logic

### DIFF
--- a/pkg/controllers/controller.go
+++ b/pkg/controllers/controller.go
@@ -95,6 +95,8 @@ func NewController(conf Config) (*Controller, error) {
 		nodeSelectorFunc = func(node *corev1.Node) bool {
 			return selector.Matches(labels.Set(node.Annotations))
 		}
+		// client-go supports label filtering, so ignore this.
+		// } else if conf.ManageNodesWithLabelSelector != "" {
 	}
 
 	var lockPodsOnNodeFunc func(ctx context.Context, nodeName string) error


### PR DESCRIPTION
The parameter manageNodesWithLabelSelector is used in client-go opt filter logic , while the parameter manageNodesWithAnnotationSelector is in NodeController's filter nodeSelectorFunc logic, that confused me..