### PR TITLE
make build support macos m1

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -50,6 +50,8 @@ KWOK_IMAGE ?= $(STAGING_IMAGE_PREFIX)/kwok
 
 CLUSTER_IMAGE ?= $(STAGING_IMAGE_PREFIX)/cluster
 
+PLATFORM ?= $(shell ./hack/get-platform.sh)
+
 IMAGE_PLATFORMS ?= linux/amd64 linux/arm64
 
 BINARY_PLATFORMS ?= linux/amd64 linux/arm64 darwin/amd64 darwin/arm64 windows/amd64 windows/arm64
@@ -78,6 +80,7 @@ build: vendor
 	@./hack/releases.sh \
 		$(addprefix --bin=, $(BINARY)) \
 		$(addprefix --extra-tag=, $(EXTRA_TAGS)) \
+		--platform=${PLATFROM} \
 		--bucket=${BUCKET} \
 		--gh-release=${GH_RELEASE} \
 		--image-prefix=${IMAGE_PREFIX} \
@@ -112,6 +115,7 @@ cross-build: vendor
 image:
 	@./images/kwok/build.sh \
 		$(addprefix --extra-tag=, $(EXTRA_TAGS)) \
+		--platform=${PLATFROM} \
 		--image=${KWOK_IMAGE} \
 		--version=${VERSION} \
 		--staging-prefix=${STAGING_PREFIX} \

--- a/hack/get-platform.sh
+++ b/hack/get-platform.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+# Copyright 2022 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# get architecture of the machine
+function arch() {
+  local arch
+  arch="$(uname -m)"
+
+  case "${arch}" in
+  x86_64 | amd64 | x64)
+    echo "amd64"
+    ;;
+  i386 | i486 | i586 | i686 | x86)
+    echo "386"
+    ;;
+  armv8* | aarch64* | arm64)
+    echo "arm64"
+    ;;
+  armv7* | armhf)
+    echo "arm"
+    ;;
+  *)
+    echo "${arch}"
+    ;;
+  esac
+}
+
+# get os of the system
+function os() {
+  local os
+  os="$(uname -s)"
+
+  echo "${os,,}"
+}
+
+echo "$(os)/$(arch)"


### PR DESCRIPTION
Signed-off-by: carlory <baofa.fan@daocloud.io>

```
(⎈ |ik8s01:argocd)➜  kwok git:(main) make build
GOOS=linux GOARCH=amd64 go build -ldflags '-X sigs.k8s.io/kwok/pkg/consts.Version=v0.0.1-22-g5676d60 -X sigs.k8s.io/kwok/pkg/consts.KubeVersion=v1.25.3' -o ./bin/linux/amd64/kwok ./cmd/kwok
GOOS=linux GOARCH=amd64 go build -ldflags '-X sigs.k8s.io/kwok/pkg/consts.Version=v0.0.1-22-g5676d60 -X sigs.k8s.io/kwok/pkg/consts.KubeVersion=v1.25.3' -o ./bin/linux/amd64/kwokctl ./cmd/kwokctl
(⎈ |ik8s01:argocd)➜  kwok git:(main) ./bin/linux/amd64/kwokctl
zsh: exec format error: ./bin/linux/amd64/kwokctl
```

/kind feature