### PR TITLE
kwok & kwokctl support the --version flag

### DIFF
--- a/pkg/kwok/cmd/root.go
+++ b/pkg/kwok/cmd/root.go
@@ -32,6 +32,7 @@ import (
 	"k8s.io/client-go/tools/clientcmd"
 	"k8s.io/client-go/util/flowcontrol"
 
+	"sigs.k8s.io/kwok/pkg/consts"
 	"sigs.k8s.io/kwok/pkg/kwok/controllers"
 	"sigs.k8s.io/kwok/pkg/kwok/controllers/templates"
 	"sigs.k8s.io/kwok/pkg/logger"
@@ -70,6 +71,7 @@ func NewCommand(logger logger.Logger) *cobra.Command {
 		Short:        "kwok is a tool for simulate thousands of fake kubelets",
 		Long:         "kwok is a tool for simulate thousands of fake kubelets",
 		SilenceUsage: true,
+		Version:      consts.Version,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if kubeconfig != "" {
 				f, err := os.Stat(kubeconfig)

--- a/pkg/kwokctl/cmd/root.go
+++ b/pkg/kwokctl/cmd/root.go
@@ -19,6 +19,7 @@ package cmd
 import (
 	"github.com/spf13/cobra"
 
+	"sigs.k8s.io/kwok/pkg/consts"
 	"sigs.k8s.io/kwok/pkg/kwokctl/cmd/create"
 	del "sigs.k8s.io/kwok/pkg/kwokctl/cmd/delete"
 	"sigs.k8s.io/kwok/pkg/kwokctl/cmd/get"
@@ -32,10 +33,11 @@ import (
 // NewCommand returns a new cobra.Command for root
 func NewCommand(logger logger.Logger) *cobra.Command {
 	cmd := &cobra.Command{
-		Args:  cobra.NoArgs,
-		Use:   "kwokctl [command]",
-		Short: "Kwokctl is a Kwok cluster management tool",
-		Long:  "Kwokctl is a Kwok cluster management tool",
+		Args:    cobra.NoArgs,
+		Use:     "kwokctl [command]",
+		Short:   "Kwokctl is a Kwok cluster management tool",
+		Long:    "Kwokctl is a Kwok cluster management tool",
+		Version: consts.Version,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return cmd.Help()
 		},


### PR DESCRIPTION
ref: #72 


```shell
(⎈ |ik8s01:argocd)➜  kwok git:(support-version-print) ✗ make build
GOOS=darwin GOARCH=arm64 go build -ldflags '-X sigs.k8s.io/kwok/pkg/consts.Version=v0.0.1-30-g351ada2-dirty -X sigs.k8s.io/kwok/pkg/consts.KubeVersion=v1.25.3' -o ./bin/darwin/arm64/kwok ./cmd/kwok
GOOS=darwin GOARCH=arm64 go build -ldflags '-X sigs.k8s.io/kwok/pkg/consts.Version=v0.0.1-30-g351ada2-dirty -X sigs.k8s.io/kwok/pkg/consts.KubeVersion=v1.25.3' -o ./bin/darwin/arm64/kwokctl ./cmd/kwokctl
(⎈ |ik8s01:argocd)➜  kwok git:(support-version-print) ✗ ./bin/darwin/arm64/kwok --version
kwok version v0.0.1-30-g351ada2-dirty
(⎈ |ik8s01:argocd)➜  kwok git:(support-version-print) ✗ ./bin/darwin/arm64/kwokctl --version
kwokctl version v0.0.1-30-g351ada2-dirty

(⎈ |ik8s01:argocd)➜  kwok git:(support-version-print) ./bin/darwin/arm64/kwok -h
kwok is a tool for simulate thousands of fake kubelets

Usage:
  kwok [command] [flags]

Flags:
      --cidr string                                        CIDR of the pod ip (default "10.0.0.1/24")
      --disregard-status-with-annotation-selector string   All node/pod status excluding the ones that match the annotation selector will be watched and managed.
      --disregard-status-with-label-selector string        All node/pod status excluding the ones that match the label selector will be watched and managed.
  -h, --help                                               help for kwok
      --kubeconfig string                                  Path to the kubeconfig file to use
      --manage-all-nodes                                   All nodes will be watched and managed. It's conflicted with manage-nodes-with-annotation-selector and manage-nodes-with-label-selector.
      --manage-nodes-with-annotation-selector string       Nodes that match the annotation selector will be watched and managed. It's conflicted with manage-all-nodes.
      --manage-nodes-with-label-selector string            Nodes that match the label selector will be watched and managed. It's conflicted with manage-all-nodes.
      --master string                                      Server is the address of the kubernetes cluster
      --node-ip ip                                         IP of the node (default 196.168.0.1)
      --server-address string                              Address to expose health and metrics on
  -v, --version                                            version for kwok
(⎈ |ik8s01:argocd)➜  kwok git:(support-version-print) ./bin/darwin/arm64/kwokctl -h
Kwokctl is a Kwok cluster management tool

Usage:
  kwokctl [command] [flags]
  kwokctl [command]

Available Commands:
  completion  Generate the autocompletion script for the specified shell
  create      Creates one of [cluster]
  delete      Deletes one of [cluster]
  get         Gets one of [artifacts, clusters, kubeconfig]
  help        Help about any command
  kubectl     kubectl in cluster
  logs        Logs one of [audit, etcd, kube-apiserver, kube-controller-manager, kube-scheduler, kwok-controller, prometheus]
  snapshot    Snapshot [save, restore] one of cluster

Flags:
  -h, --help          help for kwokctl
      --name string   cluster name (default "kwok")
  -v, --version       version for kwokctl

Use "kwokctl [command] --help" for more information about a command.
```