### PR TITLE
fix staticcheck

### DIFF
--- a/pkg/kwok/controllers/node_controller.go
+++ b/pkg/kwok/controllers/node_controller.go
@@ -203,10 +203,7 @@ loop:
 }
 
 func (c *NodeController) needHeartbeat(node *corev1.Node) bool {
-	if !c.nodeSelectorFunc(node) {
-		return false
-	}
-	return true
+	return c.nodeSelectorFunc(node)
 }
 
 func (c *NodeController) needLockNode(node *corev1.Node) bool {
@@ -337,7 +334,7 @@ func (c *NodeController) LockNode(ctx context.Context, nodeName string) error {
 	if patch == nil {
 		return nil
 	}
-	node, err = c.clientSet.CoreV1().Nodes().PatchStatus(ctx, node.Name, patch)
+	_, err = c.clientSet.CoreV1().Nodes().PatchStatus(ctx, node.Name, patch)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
/kind cleanup

```

        "resource": "/Users/kiki/workspace/golang/src/sigs.k8s.io/kwok/pkg/kwok/controllers/node_controller.go",
        "owner": "go-staticcheck",
        "severity": 4,
        "message": "should use 'return c.nodeSelectorFunc(node)' instead of 'if !c.nodeSelectorFunc(node) { return false }; return true' (S1008)",
        "source": "go-staticcheck",
        "startLineNumber": 206,
        "startColumn": 2,
        "endLineNumber": 206,
        "endColumn": 32


        "resource": "/Users/kiki/workspace/golang/src/sigs.k8s.io/kwok/pkg/kwok/controllers/node_controller.go",
        "owner": "go-staticcheck",
        "severity": 4,
        "message": "this value of node is never used (SA4006)",
        "source": "go-staticcheck",
        "startLineNumber": 340,
        "startColumn": 2,
        "endLineNumber": 340,
        "endColumn": 77
```