### PR TITLE
Fix the fetch platform error

### DIFF
--- a/hack/get-platform.sh
+++ b/hack/get-platform.sh
@@ -42,7 +42,7 @@ function os() {
   local os
   os="$(uname -s)"
 
-  echo "${os,,}"
+  echo "${os}" | tr '[:upper:]' '[:lower:]'
 }
 
 echo "$(os)/$(arch)"


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

When executing make build on macos, the following error occurs and the binary target location is incorrect. This pr fixes this error
```sh
➜  kwok git:(main) ✗ make build
./hack/get-platform.sh: line 45: ${os,,}: bad substitution
GOOS= GOARCH=amd64 go build -ldflags '-X sigs.k8s.io/kwok/pkg/consts.Version=v1.0-2-gc70ae71 -X sigs.k8s.io/kwok/pkg/consts.KubeVersion=v1.25.3' -o ./bin//amd64/kwok ./cmd/kwok
GOOS= GOARCH=amd64 go build -ldflags '-X sigs.k8s.io/kwok/pkg/consts.Version=v1.0-2-gc70ae71 -X sigs.k8s.io/kwok/pkg/consts.KubeVersion=v1.25.3' -o ./bin//amd64/kwokctl ./cmd/kwokctl

```

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note

```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
