### PR TITLE
Fix the error log output empty problem

### DIFF
--- a/pkg/log/logger_ctl.go
+++ b/pkg/log/logger_ctl.go
@@ -56,11 +56,18 @@ func formatValue(val slog.Value) string {
 	case slog.StringKind:
 		return quoteIfNeed(val.String())
 	default:
-		v, err := json.Marshal(val.Any())
-		if err == nil {
-			return string(v)
+		switch x := val.Any().(type) {
+		case error:
+			return quoteIfNeed(x.Error())
+		case fmt.Stringer:
+			return quoteIfNeed(x.String())
+		default:
+			v, err := json.Marshal(x)
+			if err == nil {
+				return string(v)
+			}
+			return quoteIfNeed(val.String())
 		}
-		return quoteIfNeed(val.String())
 	}
 }
 

--- a/pkg/log/logger_ctl_test.go
+++ b/pkg/log/logger_ctl_test.go
@@ -1,0 +1,57 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package log
+
+import (
+	"errors"
+	"testing"
+
+	"golang.org/x/exp/slog"
+)
+
+func Test_formatValue(t *testing.T) {
+	type args struct {
+		val slog.Value
+	}
+	tests := []struct {
+		name string
+		args args
+		want string
+	}{
+		{
+			name: "format for error",
+			args: args{
+				val: slog.AnyValue(errors.New("unknown command \"subcommand\" for \"kwokctl\"")),
+			},
+			want: quoteIfNeed(errors.New("unknown command \"subcommand\" for \"kwokctl\"").Error()),
+		},
+		{
+			name: "format for string",
+			args: args{
+				val: slog.AnyValue("unknown command \"subcommand\" for \"kwokctl\""),
+			},
+			want: quoteIfNeed("unknown command \"subcommand\" for \"kwokctl\""),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := formatValue(tt.args.val); got != tt.want {
+				t.Errorf("formatValue() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

If an error is generated, the following output is printed. The reason is that when `any` type is converted to `string`, the `json` package `string` becomes empty after it is used. This pr solves this problem
```sh
➜  kwok kwokctl adfadfd
ERROR Execute exit                                                                              err={}
```

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Fix the error log output empty problem
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
