### PR TITLE
build: fix generate outside go path

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -82,6 +82,11 @@ unit-test: vendor
 verify:
 	@./hack/verify-all.sh
 
+## generate: Generate deepcopy,default,conversion
+.PHONY: generate
+generate:
+	$(GO_CMD) generate ./pkg/...
+
 ## build: Build binary
 .PHONY: build
 build: vendor

--- a/pkg/apis/doc.go
+++ b/pkg/apis/doc.go
@@ -16,7 +16,7 @@ limitations under the License.
 
 package apis
 
-//go:generate go run k8s.io/code-generator/cmd/deepcopy-gen@latest -i ./v1alpha1/ --trim-path-prefix sigs.k8s.io/kwok/pkg/apis -o ./ -O zz_generated.deepcopy --go-header-file ../../hack/tools/boilerplate.go.txt
-//go:generate go run k8s.io/code-generator/cmd/defaulter-gen@latest -i ./v1alpha1/ --trim-path-prefix sigs.k8s.io/kwok/pkg/apis -o ./ -O zz_generated.defaults --go-header-file ../../hack/tools/boilerplate.go.txt
-//go:generate go run k8s.io/code-generator/cmd/deepcopy-gen@latest -i ./internalversion/ --trim-path-prefix sigs.k8s.io/kwok/pkg/apis -o ./ -O zz_generated.deepcopy --go-header-file ../../hack/tools/boilerplate.go.txt
-//go:generate go run k8s.io/code-generator/cmd/conversion-gen@latest -i ./internalversion/ --trim-path-prefix sigs.k8s.io/kwok/pkg/apis -o ./ -O zz_generated.conversion --go-header-file ../../hack/tools/boilerplate.go.txt
+//go:generate go run k8s.io/code-generator/cmd/deepcopy-gen@latest --input-dirs sigs.k8s.io/kwok/pkg/apis/v1alpha1/ --trim-path-prefix sigs.k8s.io/kwok/pkg/apis -o ./ -O zz_generated.deepcopy --go-header-file ../../hack/tools/boilerplate.go.txt
+//go:generate go run k8s.io/code-generator/cmd/defaulter-gen@latest --input-dirs sigs.k8s.io/kwok/pkg/apis/v1alpha1/ --trim-path-prefix sigs.k8s.io/kwok/pkg/apis -o ./ -O zz_generated.defaults --go-header-file ../../hack/tools/boilerplate.go.txt
+//go:generate go run k8s.io/code-generator/cmd/deepcopy-gen@latest --input-dirs sigs.k8s.io/kwok/pkg/apis/internalversion/ --trim-path-prefix sigs.k8s.io/kwok/pkg/apis -o ./ -O zz_generated.deepcopy --go-header-file ../../hack/tools/boilerplate.go.txt
+//go:generate go run k8s.io/code-generator/cmd/conversion-gen@latest --input-dirs sigs.k8s.io/kwok/pkg/apis/internalversion/ --trim-path-prefix sigs.k8s.io/kwok/pkg/apis -o ./ -O zz_generated.conversion --go-header-file ../../hack/tools/boilerplate.go.txt


### PR DESCRIPTION
Signed-off-by: WeiZhang <kweizh@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/kind bug

#### What this PR does / why we need it:

we use code-generator to generate code, but when working outside GOPATH, it will report error and generate wrong code:

```
$ go generate ./pkg/...
# k8s.io/code-generator/cmd/deepcopy-gen
ld: warning: -no_pie is deprecated when targeting new OS versions
# k8s.io/code-generator/cmd/defaulter-gen
ld: warning: -no_pie is deprecated when targeting new OS versions
# k8s.io/code-generator/cmd/deepcopy-gen
ld: warning: -no_pie is deprecated when targeting new OS versions
# k8s.io/code-generator/cmd/conversion-gen
ld: warning: -no_pie is deprecated when targeting new OS versions
E0118 17:23:27.840791   63092 conversion.go:193] Rename function ./internalversion/ Convert_v1alpha1_KwokctlConfigurationOptions_To_internalversion_KwokctlConfigurationOptions -> Convert_v1alpha1_KwokctlConfigura
tionOptions_To__KwokctlConfigurationOptions to match expected conversion signature
E0118 17:23:27.862496   63092 conversion.go:756] Warning: could not find nor generate a final Conversion function for sigs.k8s.io/kwok/pkg/apis/v1alpha1.KwokctlConfigurationOptions -> ./internalversion/.KwokctlCo
nfigurationOptions
E0118 17:23:27.862565   63092 conversion.go:757]   the following fields need manual conversion:
E0118 17:23:27.862580   63092 conversion.go:759]       - KubeImagePrefix
E0118 17:23:27.862591   63092 conversion.go:759]       - EtcdImagePrefix
E0118 17:23:27.862608   63092 conversion.go:759]       - KwokImagePrefix
E0118 17:23:27.862619   63092 conversion.go:759]       - PrometheusImagePrefix
E0118 17:23:27.862629   63092 conversion.go:759]       - KindNodeImagePrefix
E0118 17:23:27.862639   63092 conversion.go:759]       - KubeBinaryPrefix
E0118 17:23:27.862650   63092 conversion.go:759]       - EtcdBinaryPrefix
E0118 17:23:27.862662   63092 conversion.go:759]       - KwokBinaryPrefix
E0118 17:23:27.862675   63092 conversion.go:759]       - PrometheusBinaryPrefix
E0118 17:23:27.862690   63092 conversion.go:759]       - DockerComposeBinaryPrefix
E0118 17:23:27.862706   63092 conversion.go:759]       - KindBinaryPrefix
```

this PR: 
1. makes the code generator work when outside GOPATH
2. add a make command to generate code

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note

```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
