### PR TITLE
[kwokctl] Support port exposure for controller-port

### DIFF
--- a/pkg/apis/internalversion/kwokctl_configuration_types.go
+++ b/pkg/apis/internalversion/kwokctl_configuration_types.go
@@ -36,7 +36,6 @@ type KwokctlConfiguration struct {
 
 // KwokctlConfigurationOptions holds information about the options.
 type KwokctlConfigurationOptions struct {
-
 	// KubeApiserverPort is the port to expose apiserver.
 	KubeApiserverPort uint32
 
@@ -164,7 +163,7 @@ type KwokctlConfigurationOptions struct {
 	// KubeSchedulerPort is kube-scheduler port in the binary runtime
 	KubeSchedulerPort uint32
 
-	// KwokControllerPort is kube-controller port in the binary runtime
+	// KwokControllerPort is kwok-controller port that is exposed to the host.
 	KwokControllerPort uint32
 
 	// CacheDir is the directory of the cache.

--- a/pkg/apis/v1alpha1/kwokctl_configuration_types.go
+++ b/pkg/apis/v1alpha1/kwokctl_configuration_types.go
@@ -259,7 +259,8 @@ type KwokctlConfigurationOptions struct {
 	// KubeSchedulerPort is kube-scheduler port in the binary runtime
 	KubeSchedulerPort uint32 `json:"kubeSchedulerPort,omitempty"`
 
-	// KwokControllerPort is kube-controller port in the binary runtime
+	// KwokControllerPort is kwok-controller port that is exposed to the host.
+	// is the default value for flag --controller-port and env KWOK_CONTROLLER_PORT
 	KwokControllerPort uint32 `json:"kwokControllerPort,omitempty"`
 
 	// CacheDir is the directory of the cache.

--- a/pkg/config/vars.go
+++ b/pkg/config/vars.go
@@ -277,6 +277,7 @@ func setKwokctlKwokConfig(conf *v1alpha1.KwokctlConfigurationOptions) {
 		conf.KwokControllerImage = joinImageURI(conf.KwokImagePrefix, "kwok", conf.KwokVersion)
 	}
 	conf.KwokControllerImage = envs.GetEnvWithPrefix("CONTROLLER_IMAGE", conf.KwokControllerImage)
+	conf.KwokControllerPort = envs.GetEnvWithPrefix("CONTROLLER_PORT", conf.KwokControllerPort)
 }
 
 func setKwokctlEtcdConfig(conf *v1alpha1.KwokctlConfigurationOptions) {

--- a/pkg/kwokctl/cmd/create/cluster/cluster.go
+++ b/pkg/kwokctl/cmd/create/cluster/cluster.go
@@ -82,6 +82,7 @@ func NewCommand(ctx context.Context) *cobra.Command {
 	cmd.Flags().StringVar(&flags.Options.PrometheusImage, "prometheus-image", flags.Options.PrometheusImage, `Image of Prometheus, only for docker/nerdctl/kind runtime
 '${KWOK_PROMETHEUS_IMAGE_PREFIX}/prometheus:${KWOK_PROMETHEUS_VERSION}'
 `)
+	cmd.Flags().Uint32Var(&flags.Options.KwokControllerPort, "controller-port", flags.Options.KwokControllerPort, `Port of kwok-controller given to the host`)
 	cmd.Flags().StringVar(&flags.Options.KindNodeImage, "kind-node-image", flags.Options.KindNodeImage, `Image of kind node, only for kind runtime
 '${KWOK_KIND_NODE_IMAGE_PREFIX}/node:${KWOK_KUBE_VERSION}'
 `)

--- a/pkg/kwokctl/components/kwok_controller.go
+++ b/pkg/kwokctl/components/kwok_controller.go
@@ -44,6 +44,7 @@ func BuildKwokControllerComponent(conf BuildKwokControllerComponentConfig) (comp
 
 	inContainer := conf.Image != ""
 	var volumes []internalversion.Volume
+	var ports []internalversion.Port
 
 	if inContainer {
 		volumes = append(volumes,
@@ -68,6 +69,14 @@ func BuildKwokControllerComponent(conf BuildKwokControllerComponentConfig) (comp
 				ReadOnly:  true,
 			},
 		)
+		if conf.Port != 0 {
+			ports = append(ports,
+				internalversion.Port{
+					HostPort: conf.Port,
+					Port:     10247,
+				},
+			)
+		}
 		kwokControllerArgs = append(kwokControllerArgs,
 			"--kubeconfig=/root/.kube/config",
 			"--config=/root/.kwok/kwok.yaml",
@@ -93,6 +102,7 @@ func BuildKwokControllerComponent(conf BuildKwokControllerComponentConfig) (comp
 		Links: []string{
 			"kube-apiserver",
 		},
+		Ports:   ports,
 		Command: []string{"kwok"},
 		Volumes: volumes,
 		Args:    kwokControllerArgs,

--- a/pkg/kwokctl/runtime/kind/cluster.go
+++ b/pkg/kwokctl/runtime/kind/cluster.go
@@ -98,14 +98,15 @@ func (c *Cluster) Install(ctx context.Context) error {
 
 	configPath := c.GetWorkdirPath(runtime.ConfigName)
 	kindYaml, err := BuildKind(BuildKindConfig{
-		KubeApiserverPort: conf.KubeApiserverPort,
-		PrometheusPort:    conf.PrometheusPort,
-		FeatureGates:      featureGates,
-		RuntimeConfig:     runtimeConfig,
-		AuditPolicy:       auditPolicyPath,
-		AuditLog:          auditLogPath,
-		SchedulerConfig:   schedulerConfigPath,
-		ConfigPath:        configPath,
+		KubeApiserverPort:  conf.KubeApiserverPort,
+		PrometheusPort:     conf.PrometheusPort,
+		KwokControllerPort: conf.KwokControllerPort,
+		FeatureGates:       featureGates,
+		RuntimeConfig:      runtimeConfig,
+		AuditPolicy:        auditPolicyPath,
+		AuditLog:           auditLogPath,
+		SchedulerConfig:    schedulerConfigPath,
+		ConfigPath:         configPath,
 	})
 	if err != nil {
 		return err

--- a/pkg/kwokctl/runtime/kind/kind.go
+++ b/pkg/kwokctl/runtime/kind/kind.go
@@ -41,8 +41,9 @@ func BuildKind(conf BuildKindConfig) (string, error) {
 
 // BuildKindConfig is the configuration for building the kind config
 type BuildKindConfig struct {
-	KubeApiserverPort uint32
-	PrometheusPort    uint32
+	KubeApiserverPort  uint32
+	PrometheusPort     uint32
+	KwokControllerPort uint32
 
 	RuntimeConfig []string
 	FeatureGates  []string

--- a/pkg/kwokctl/runtime/kind/kind.yaml.tpl
+++ b/pkg/kwokctl/runtime/kind/kind.yaml.tpl
@@ -9,12 +9,20 @@ networking:
 nodes:
 - role: control-plane
 
-{{ if .PrometheusPort }}
+{{ if or .PrometheusPort .KwokControllerPort }}
   extraPortMappings:
+  {{ if .PrometheusPort }}
   - containerPort: 9090
     hostPort: {{ .PrometheusPort }}
     listenAddress: "0.0.0.0"
     protocol: TCP
+  {{ end }}
+  {{ if .KwokControllerPort }}
+  - containerPort: 10247
+    hostPort: {{ .KwokControllerPort }}
+    listenAddress: "0.0.0.0"
+    protocol: TCP
+  {{ end }}
 {{ end }}
 
   kubeadmConfigPatches:


### PR DESCRIPTION
#### What type of PR is this?
/kind feature

#### What this PR does / why we need it:
Exposes port on host when flag or env variable is specified. 

#### Which issue(s) this PR fixes:

Fixes controller-port for #261

#### Special notes for your reviewer:
- [x] controller-port
- [ ] etcd-port
- [ ] kube-controller-manager-port
- [ ] kube-scheduler-port

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
TODO
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
TODO
```