### PR TITLE
Automated cherry pick of #275: Avoid clearing empty finalizers

### DIFF
--- a/pkg/kwok/controllers/finalizers.go
+++ b/pkg/kwok/controllers/finalizers.go
@@ -100,7 +100,10 @@ func finalizersModify(metaFinalizers []string, finalizers *internalversion.Stage
 			ops = append(ops, finalizersAdd(metaFinalizers, finalizers.Add)...)
 		}
 	} else {
-		ops = append(ops, finalizersEmpty)
+		if len(metaFinalizers) != 0 {
+			ops = append(ops, finalizersEmpty)
+		}
+
 		if len(finalizers.Add) != 0 {
 			ops = append(ops, finalizersAdd(nil, finalizers.Add)...)
 		}


### PR DESCRIPTION
Cherry pick of #275 on release-0.1.

#275: Avoid clearing empty finalizers

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note

```