### PR TITLE
Automated cherry pick of #277: Fix default stages name

### DIFF
--- a/pkg/kwok/controllers/lifecycle.go
+++ b/pkg/kwok/controllers/lifecycle.go
@@ -29,22 +29,27 @@ import (
 	"k8s.io/apimachinery/pkg/util/yaml"
 
 	"sigs.k8s.io/kwok/pkg/apis/internalversion"
+	"sigs.k8s.io/kwok/pkg/apis/v1alpha1"
 	"sigs.k8s.io/kwok/pkg/utils/expression"
 	"sigs.k8s.io/kwok/pkg/utils/format"
 )
 
 func NewStagesFromYaml(data []byte) ([]*internalversion.Stage, error) {
-	var podStageStatus []*internalversion.Stage
+	var stages []*internalversion.Stage
 	decoder := yaml.NewYAMLToJSONDecoder(bytes.NewBuffer(data))
 	for {
-		var stage internalversion.Stage
+		var stage v1alpha1.Stage
 		err := decoder.Decode(&stage)
 		if errors.Is(err, io.EOF) {
 			break
 		}
-		podStageStatus = append(podStageStatus, &stage)
+		internalStage, err := internalversion.ConvertToInternalVersionStage(&stage)
+		if err != nil {
+			return nil, err
+		}
+		stages = append(stages, internalStage)
 	}
-	return podStageStatus, nil
+	return stages, nil
 }
 
 func NewLifecycle(stages []*internalversion.Stage) (Lifecycle, error) {

--- a/pkg/kwok/controllers/lifecycle_test.go
+++ b/pkg/kwok/controllers/lifecycle_test.go
@@ -1,0 +1,78 @@
+/*
+Copyright 2023 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controllers
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"sigs.k8s.io/kwok/pkg/apis/internalversion"
+)
+
+func TestNewStagesFromYaml(t *testing.T) {
+	type args struct {
+		data []byte
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    []*internalversion.Stage
+		wantErr bool
+	}{
+		{
+			name: "empty",
+			args: args{
+				data: []byte(`kind: Stage
+apiVersion: kwok.x-k8s.io/v1alpha1
+metadata:
+  name: node-test
+spec:
+  resourceRef:
+    apiGroup: v1
+    kind: Node`),
+			},
+			want: []*internalversion.Stage{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "node-test",
+					},
+					Spec: internalversion.StageSpec{
+						ResourceRef: internalversion.StageResourceRef{
+							APIGroup: "v1",
+							Kind:     "Node",
+						},
+					},
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := NewStagesFromYaml(tt.args.data)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("NewStagesFromYaml() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+
+			if diff := cmp.Diff(got, tt.want); diff != "" {
+				t.Errorf("NewStagesFromYaml() diff (-got +want): %s", diff)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Cherry pick of #277 on release-0.1.

#277: Fix default stages name

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note

```