### PR TITLE
Bump Hugo version

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -5,7 +5,7 @@ publish = "public/"
 command = "make build"
 
 [build.environment]
-HUGO_VERSION = "0.107.0"
+HUGO_VERSION = "0.110.0"
 
 [context.production.environment]
 # this controls our robots.txt

--- a/site/Makefile
+++ b/site/Makefile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-HUGO_VERSION = 0.107.0
+HUGO_VERSION = 0.110.0
 HUGO_IMAGE = docker.io/klakegg/hugo:$(HUGO_VERSION)-ext
 HUGO_BINARY  = $(shell which hugo)
 HUGO_DOCKER  = docker run --rm -it --volume $(realpath $(CURDIR)/..):/src -p 1313:1313 --workdir /src/site --entrypoint=hugo $(HUGO_IMAGE)


### PR DESCRIPTION
#### What type of PR is this?

/kind documentation

#### What this PR does / why we need it:

Use [Hugo 0.110.0](https://github.com/gohugoio/hugo/releases/tag/v0.110.0) to build the site.
Hugo 0.110.0 was the latest available at time I checked.

Refer to  https://github.com/kubernetes/website/pull/39522.

#### Which issue(s) this PR fixes:

Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs
NONE
```
