### PR TITLE
check src exists and use abspath

### DIFF
--- a/pkg/kwok/cmd/root.go
+++ b/pkg/kwok/cmd/root.go
@@ -70,7 +70,11 @@ func NewCommand(ctx context.Context) *cobra.Command {
 			logger := log.FromContext(ctx)
 
 			if flags.Kubeconfig != "" {
-				flags.Kubeconfig = path.ExpandHome(flags.Kubeconfig)
+				var err error
+				flags.Kubeconfig, err = path.Expand(flags.Kubeconfig)
+				if err != nil {
+					return err
+				}
 				f, err := os.Stat(flags.Kubeconfig)
 				if err != nil || f.IsDir() {
 					logger.Warn("Failed to get kubeconfig file or it is a directory", "kubeconfig", flags.Kubeconfig)

--- a/pkg/utils/file/download.go
+++ b/pkg/utils/file/download.go
@@ -114,7 +114,14 @@ func getCachePath(cacheDir, src string) (string, error) {
 	case "http", "https":
 		return path.Join(cacheDir, u.Scheme, u.Host, u.Path), nil
 	default:
-		return src, nil
+		src, err = path.Expand(src)
+		if err != nil {
+			return "", err
+		}
+		if _, err := os.Stat(src); err != nil {
+			return "", err
+		}
+		return src, err
 	}
 }
 

--- a/pkg/utils/path/path.go
+++ b/pkg/utils/path/path.go
@@ -17,25 +17,28 @@ limitations under the License.
 package path
 
 import (
+	"fmt"
 	"os"
+	"path/filepath"
 )
 
-// ExpandHome expands home directory in file paths.
-func ExpandHome(path string) string {
-	if len(path) == 0 {
-		return path
-	}
-	if path[0] != '~' {
-		return path
-	}
-	if len(path) > 1 && path[1] != '/' && path[1] != '\\' {
-		return path
+// Expand expands absolute directory in file paths.
+func Expand(path string) (string, error) {
+	if path == "" {
+		return "", fmt.Errorf("empty path")
 	}
 
-	home, err := os.UserHomeDir()
-	if err != nil {
-		return path
+	if path[0] == '~' {
+		home, err := os.UserHomeDir()
+		if err != nil {
+			return "", err
+		}
+		if len(path) == 1 {
+			path = home
+		} else if path[1] == '/' || path[1] == '\\' {
+			path = Join(home, path[2:])
+		}
 	}
 
-	return Join(home, path[1:])
+	return filepath.Abs(path)
 }

--- a/pkg/utils/path/path_test.go
+++ b/pkg/utils/path/path_test.go
@@ -1,0 +1,108 @@
+/*
+Copyright 2023 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package path
+
+import (
+	"os"
+	"testing"
+)
+
+func TestExpand(t *testing.T) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		t.Fatal(err)
+		return
+	}
+
+	wd, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+		return
+	}
+
+	var testCases = []struct {
+		name     string
+		input    string
+		expected string
+		wantErr  bool
+	}{
+		{
+			name:     "empty path",
+			input:    "",
+			expected: "",
+			wantErr:  true,
+		},
+		{
+			name:     "tilde and dot",
+			input:    "~/./example.txt",
+			expected: Join(home, "example.txt"),
+			wantErr:  false,
+		},
+		{
+			name:     "tilde and dotdot",
+			input:    "~/../example.txt",
+			expected: Join(home, "../example.txt"),
+			wantErr:  false,
+		},
+		{
+			name:     "tilde",
+			input:    "~",
+			expected: home,
+			wantErr:  false,
+		},
+		{
+			name:     "tilde slash",
+			input:    "~/example.txt",
+			expected: Join(home, "example.txt"),
+			wantErr:  false,
+		},
+		{
+			name:     "absolute path",
+			input:    "/example.txt",
+			expected: "/example.txt",
+			wantErr:  false,
+		},
+		{
+			name:     "pwd path",
+			input:    "example.txt",
+			expected: Join(wd, "example.txt"),
+			wantErr:  false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			output, err := Expand(tc.input)
+
+			if tc.wantErr {
+				if err == nil {
+					t.Errorf("Expected error, but got nil")
+				}
+				return
+			}
+
+			if err != nil {
+				t.Errorf("Unexpected error: %v", err)
+				return
+			}
+
+			if output != tc.expected {
+				t.Errorf("Expected %s, but got %s", tc.expected, output)
+			}
+		})
+	}
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind feature

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
- check whether the local binary exists.
- symlink cannot point to a file with a relative path
#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:
When debugging by specifying a local kwok-controller-binary, it is found that the cluster cannot be created normally. During troubleshooting, it is found that the files with relative paths will be linked by symbols when kwok-controller-binary use local files.

use `./kwokctl create cluster --name m1 --kwok-controller-binary ./kwok`

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
