### PR TITLE
[kwokctl] Support port exposure for etcd-port

### DIFF
--- a/pkg/config/vars.go
+++ b/pkg/config/vars.go
@@ -331,6 +331,8 @@ func setKwokctlEtcdConfig(conf *v1alpha1.KwokctlConfigurationOptions) {
 		conf.EtcdImage = joinImageURI(conf.EtcdImagePrefix, "etcd", conf.EtcdVersion)
 	}
 	conf.EtcdImage = envs.GetEnvWithPrefix("ETCD_IMAGE", conf.EtcdImage)
+
+	conf.EtcdPort = envs.GetEnvWithPrefix("ETCD_PORT", conf.EtcdPort)
 }
 
 func setKwokctlKindConfig(conf *v1alpha1.KwokctlConfigurationOptions) {

--- a/pkg/kwokctl/cmd/create/cluster/cluster.go
+++ b/pkg/kwokctl/cmd/create/cluster/cluster.go
@@ -67,6 +67,7 @@ func NewCommand(ctx context.Context) *cobra.Command {
 	cmd.Flags().StringVar(&flags.Options.EtcdImage, "etcd-image", flags.Options.EtcdImage, `Image of etcd, only for docker/nerdctl runtime
 '${KWOK_KUBE_IMAGE_PREFIX}/etcd:${KWOK_ETCD_VERSION}'
 `)
+	cmd.Flags().Uint32Var(&flags.Options.EtcdPort, "etcd-port", flags.Options.EtcdPort, `Port of etcd given to the host. The behavior is unstable for kind runtime and may be modified in the future`)
 	cmd.Flags().StringVar(&flags.Options.KubeApiserverImage, "kube-apiserver-image", flags.Options.KubeApiserverImage, `Image of kube-apiserver, only for docker/nerdctl runtime
 '${KWOK_KUBE_IMAGE_PREFIX}/kube-apiserver:${KWOK_KUBE_VERSION}'
 `)

--- a/pkg/kwokctl/components/kube_apiserver.go
+++ b/pkg/kwokctl/components/kube_apiserver.go
@@ -59,10 +59,10 @@ func BuildKubeApiserverComponent(conf BuildKubeApiserverComponentConfig) (compon
 
 	kubeApiserverArgs := []string{
 		"--admission-control=",
-		"--etcd-servers=http://" + conf.EtcdAddress + ":" + format.String(conf.EtcdPort),
 		"--etcd-prefix=/registry",
 		"--allow-privileged=true",
 	}
+
 	if conf.KubeRuntimeConfig != "" {
 		kubeApiserverArgs = append(kubeApiserverArgs,
 			"--runtime-config="+conf.KubeRuntimeConfig,
@@ -74,9 +74,19 @@ func BuildKubeApiserverComponent(conf BuildKubeApiserverComponentConfig) (compon
 		)
 	}
 
-	inContainer := conf.Image != ""
 	var ports []internalversion.Port
 	var volumes []internalversion.Volume
+
+	inContainer := conf.Image != ""
+	if inContainer {
+		kubeApiserverArgs = append(kubeApiserverArgs,
+			"--etcd-servers=http://"+conf.EtcdAddress+":2379",
+		)
+	} else {
+		kubeApiserverArgs = append(kubeApiserverArgs,
+			"--etcd-servers=http://"+conf.EtcdAddress+":"+format.String(conf.EtcdPort),
+		)
+	}
 
 	if conf.SecurePort {
 		if conf.KubeAuthorization {

--- a/pkg/kwokctl/runtime/kind/cluster.go
+++ b/pkg/kwokctl/runtime/kind/cluster.go
@@ -109,6 +109,7 @@ func (c *Cluster) Install(ctx context.Context) error {
 	configPath := c.GetWorkdirPath(runtime.ConfigName)
 	kindYaml, err := BuildKind(BuildKindConfig{
 		KubeApiserverPort:  conf.KubeApiserverPort,
+		EtcdPort:           conf.EtcdPort,
 		PrometheusPort:     conf.PrometheusPort,
 		KwokControllerPort: conf.KwokControllerPort,
 		FeatureGates:       featureGates,

--- a/pkg/kwokctl/runtime/kind/kind.go
+++ b/pkg/kwokctl/runtime/kind/kind.go
@@ -42,6 +42,7 @@ func BuildKind(conf BuildKindConfig) (string, error) {
 // BuildKindConfig is the configuration for building the kind config
 type BuildKindConfig struct {
 	KubeApiserverPort  uint32
+	EtcdPort           uint32
 	PrometheusPort     uint32
 	KwokControllerPort uint32
 

--- a/pkg/kwokctl/runtime/kind/kind.yaml.tpl
+++ b/pkg/kwokctl/runtime/kind/kind.yaml.tpl
@@ -9,7 +9,7 @@ networking:
 nodes:
 - role: control-plane
 
-{{ if or .PrometheusPort .KwokControllerPort }}
+{{ if or .PrometheusPort .KwokControllerPort .EtcdPort }}
   extraPortMappings:
   {{ if .PrometheusPort }}
   - containerPort: 9090
@@ -20,6 +20,12 @@ nodes:
   {{ if .KwokControllerPort }}
   - containerPort: 10247
     hostPort: {{ .KwokControllerPort }}
+    listenAddress: "0.0.0.0"
+    protocol: TCP
+  {{ end }}
+  {{ if .EtcdPort }}
+  - containerPort: 2379
+    hostPort: {{ .EtcdPort }}
     listenAddress: "0.0.0.0"
     protocol: TCP
   {{ end }}


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

Allow access to the etcd from the host machine

#### Which issue(s) this PR fixes:

Related to #261 (etcd-port)

#### Special notes for your reviewer:

This is currently using nc to test connectivity. The `curl` command to query a version will fail on kind since the host does not have a valid cert. This might cause failure on binary runtime CI because the nc is not installed.