### PR TITLE
[Docs] add get-started to userguide

### DIFF
--- a/site/content/en/_index.md
+++ b/site/content/en/_index.md
@@ -20,23 +20,12 @@ KWOK stands for Kubernetes WithOut Kubelet. So far, it provides two tools:
 
 ## Getting Started
 
-The following examples are tested to work with the latest version of `kwok`/`kwokctl`.
+The animation below shows a test process to work with the latest version of `kwok`/`kwokctl`.
 
 <img width="700px" src="/manage-clusters.svg">
 
-### Basic Usage
-
-- [`kwok` Manages Nodes and Pods]({{< relref "/docs/user/kwok-manage-nodes-and-pods" >}}) - Basic operations of `kwok` to manage Nodes and Pods
-- `kwok` - maintain Nodes heartbeat and Pods status.
-    - [`kwok` in Cluster]({{< relref "/docs/user/kwok-in-cluster" >}}) - Installing `kwok` in a cluster
-    - [`kwok` in Local]({{< relref "/docs/user/kwok-in-local" >}}) - Run `kwok` in the local for a cluster
-- `kwokctl` - cluster creation, etcd snapshot, etc.
-    - [`kwokctl` Manages Clusters]({{< relref "/docs/user/kwokctl-manage-cluster" >}}) - Create/Delete a cluster in local where all nodes are managed by `kwok`
-    - [`kwokctl` Snapshots Cluster]({{< relref "/docs/user/kwokctl-snapshot" >}}) - Save/Restore the Etcd data of a cluster created by `kwokctl`
-
-### Contributing
-
-- [Contributing]({{< relref "/docs/contributing/getting-started" >}}) - How to contribute to KWOK
+Welcome to [get started]({{< relref "/docs/user/getting-started" >}}) with the installation, basic usage, custom configuration,
+and [contribution to KWOK]({{< relref "/docs/contributing/getting-started" >}}).
 
 ## `kwokctl` Runtime and OS Support
 

--- a/site/content/en/docs/user/getting-started.md
+++ b/site/content/en/docs/user/getting-started.md
@@ -1,0 +1,34 @@
+# Getting Started
+
+{{< hint "info" >}}
+
+This document walks you through how you can get started with KWOK easily.
+
+{{< /hint >}}
+
+Getting started with an open project like KWOK can be a great way to learn more
+about Kubernetes. Here are some tips to help you get started.
+
+## Installation
+
+- [Install with Homebrew]({{< relref "/docs/user/install#homebrew" >}}) - Applicable to your local Linux/MacOS
+- [Install binary releases]({{< relref "/docs/user/install#binary-releases" >}})
+
+## Basic Usage
+
+- [`kwok` Manages Nodes and Pods]({{< relref "/docs/user/kwok-manage-nodes-and-pods" >}}) - Basic operations of `kwok` to manage Nodes and Pods
+- `kwok` - maintain Nodes heartbeat and Pods status.
+    - [`kwok` in Cluster]({{< relref "/docs/user/kwok-in-cluster" >}}) - Installing `kwok` in a cluster
+    - [`kwok` in Local]({{< relref "/docs/user/kwok-in-local" >}}) - Run `kwok` in the local for a cluster
+- `kwokctl` - cluster creation, etcd snapshot, etc.
+    - [`kwokctl` Manages Clusters]({{< relref "/docs/user/kwokctl-manage-cluster" >}}) - Create/Delete a cluster in local where all nodes are managed by `kwok`
+    - [`kwokctl` Snapshots Cluster]({{< relref "/docs/user/kwokctl-snapshot" >}}) - Save/Restore the Etcd data of a cluster created by `kwokctl`
+
+## Configuration
+
+If any special concerns, you can configure KWOK with options and stages.
+
+- [Options]({{< relref "/docs/user/configuration" >}})
+- [Stages]({{< relref "/docs/user/stages-configuration" >}})
+
+I hope this helps you get started with KWOK! Good luck and have fun contributing to the project!

--- a/site/content/en/docs/user/kwok-in-local.md
+++ b/site/content/en/docs/user/kwok-in-local.md
@@ -1,18 +1,13 @@
-# Run `kwok` in the Local
+# Run `kwok` in Your Local
 
 {{< hint "info" >}}
 
-This document walks you through how to run `kwok` in the local.
+This document walks you through how to run `kwok` in your local.
 
 {{< /hint >}}
 
-## Install `kwok`
-
-[Install `kwok`]({{< relref "/docs/user/install" >}}) in the local.
-
-## Run `kwok` in the local
-
-Finally, we're able to run `kwok` in the local for a cluster and maintain their heartbeats:
+After you have [`kwok` installed]({{< relref "/docs/user/install" >}}) in a local computer,
+you can run `kwok` immediately for clusters and maintain their heartbeats:
 
 ``` bash
 kwok \

--- a/site/content/en/menu/index.md
+++ b/site/content/en/menu/index.md
@@ -4,6 +4,7 @@ headless: true
 
 - [Home]({{< relref "/" >}})
 - **User Guide**
+  - [Getting Started]({{< relref "/docs/user/getting-started" >}})
   - **Quick Start**
     - [All in One Image]({{< relref "/docs/user/all-in-one-image" >}})
     - [Install]({{< relref "/docs/user/install" >}})


### PR DESCRIPTION
#### What type of PR is this?

/kind documentation

#### What this PR does / why we need it:

- Mainly add a page `getting-started`
- Other minor changes

#### Which issue(s) this PR fixes:

Fixes #333

#### Does this PR introduce a user-facing change?

```release-note
NONE
```
