### PR TITLE
config: ignore empty documents while loading

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -301,6 +301,10 @@ func loadRawConfig(p string) ([]json.RawMessage, error) {
 			}
 			return nil, err
 		}
+		if len(raw) == 0 {
+			// Ignore empty documents
+			continue
+		}
 		raws = append(raws, raw)
 	}
 	return raws, nil

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -18,7 +18,10 @@ package config
 
 import (
 	"context"
+	"encoding/json"
+	"os"
 	"path/filepath"
+	"reflect"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -57,5 +60,103 @@ func TestConfig(t *testing.T) {
 
 	if diff := cmp.Diff(want, got); diff != "" {
 		t.Error(diff)
+	}
+}
+
+func Test_loadRawConfig(t *testing.T) {
+	tests := []struct {
+		name    string
+		data    []byte
+		want    []json.RawMessage
+		wantErr bool
+	}{
+		{
+			name: "single document",
+			data: []byte(`apiVersion: kwok.io/v1alpha1
+kind: KwokConfiguration
+`),
+			want: []json.RawMessage{
+				[]byte(`{"apiVersion":"kwok.io/v1alpha1","kind":"KwokConfiguration"}`),
+			},
+		},
+		{
+			name: "multiple documents",
+			data: []byte(`apiVersion: kwok.io/v1alpha1
+kind: KwokConfiguration
+---
+apiVersion: kwok.io/v1alpha1
+kind: KwokctlConfiguration
+`),
+			want: []json.RawMessage{
+				[]byte(`{"apiVersion":"kwok.io/v1alpha1","kind":"KwokConfiguration"}`),
+				[]byte(`{"apiVersion":"kwok.io/v1alpha1","kind":"KwokctlConfiguration"}`),
+			},
+		},
+		{
+			name: "empty document at start",
+			data: []byte(`# Some comment
+---
+apiVersion: kwok.io/v1alpha1
+kind: KwokConfiguration
+`),
+			want: []json.RawMessage{
+				[]byte(`{"apiVersion":"kwok.io/v1alpha1","kind":"KwokConfiguration"}`),
+			},
+		},
+		{
+			name: "empty document at end",
+			data: []byte(`apiVersion: kwok.io/v1alpha1
+kind: KwokConfiguration
+---
+# Some comment
+`),
+			want: []json.RawMessage{
+				[]byte(`{"apiVersion":"kwok.io/v1alpha1","kind":"KwokConfiguration"}`),
+			},
+		},
+		{
+			name: "empty document in middle",
+			data: []byte(`apiVersion: kwok.io/v1alpha1
+kind: KwokConfiguration
+---
+# Some comment
+---
+apiVersion: kwok.io/v1alpha1
+kind: KwokctlConfiguration
+`),
+			want: []json.RawMessage{
+				[]byte(`{"apiVersion":"kwok.io/v1alpha1","kind":"KwokConfiguration"}`),
+				[]byte(`{"apiVersion":"kwok.io/v1alpha1","kind":"KwokctlConfiguration"}`),
+			},
+		},
+		{
+			name:    "invalid document",
+			data:    []byte(`{"invalid"}"`),
+			want:    nil,
+			wantErr: true,
+		},
+		{
+			name: "empty",
+			data: []byte(``),
+			want: nil,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			p := filepath.Join(t.TempDir(), "config.yaml")
+			err := os.WriteFile(p, tt.data, 0o640)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			got, err := loadRawConfig(p)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("loadRawConfig() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("loadRawConfig() got = %v, want %v", got, tt.want)
+			}
+		})
 	}
 }


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

Ensures empty YAML documents (with e.g. comments) are ignored during config load.

#### Which issue(s) this PR fixes:

Fixes #343

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
Empty YAML documents in configuration file will now be ignored.
```