### PR TITLE
[kwokctl] Support port exposure for kube-scheduler

### DIFF
--- a/pkg/config/vars.go
+++ b/pkg/config/vars.go
@@ -267,6 +267,8 @@ func setKwokctlKubernetesConfig(conf *v1alpha1.KwokctlConfigurationOptions) {
 		conf.KubeSchedulerImage = joinImageURI(conf.KubeImagePrefix, "kube-scheduler", conf.KubeVersion)
 	}
 	conf.KubeSchedulerImage = envs.GetEnvWithPrefix("KUBE_SCHEDULER_IMAGE", conf.KubeSchedulerImage)
+
+	conf.KubeSchedulerPort = envs.GetEnvWithPrefix("KUBE_SCHEDULER_PORT", conf.KubeSchedulerPort)
 }
 
 func setKwokctlKwokConfig(conf *v1alpha1.KwokctlConfigurationOptions) {

--- a/pkg/kwokctl/cmd/create/cluster/cluster.go
+++ b/pkg/kwokctl/cmd/create/cluster/cluster.go
@@ -77,6 +77,7 @@ func NewCommand(ctx context.Context) *cobra.Command {
 	cmd.Flags().StringVar(&flags.Options.KubeSchedulerImage, "kube-scheduler-image", flags.Options.KubeSchedulerImage, `Image of kube-scheduler, only for docker/nerdctl runtime
 '${KWOK_KUBE_IMAGE_PREFIX}/kube-scheduler:${KWOK_KUBE_VERSION}'
 `)
+	cmd.Flags().Uint32Var(&flags.Options.KubeSchedulerPort, "kube-scheduler-port", flags.Options.KubeSchedulerPort, `Port of kube-scheduler given to the host, only for binary and docker/nerdctl runtime`)
 	cmd.Flags().StringVar(&flags.Options.KwokControllerImage, "kwok-controller-image", flags.Options.KwokControllerImage, `Image of kwok-controller, only for docker/nerdctl/kind runtime
 '${KWOK_IMAGE_PREFIX}/kwok:${KWOK_VERSION}'
 `)

--- a/pkg/kwokctl/components/kube_scheduler.go
+++ b/pkg/kwokctl/components/kube_scheduler.go
@@ -55,6 +55,7 @@ func BuildKubeSchedulerComponent(conf BuildKubeSchedulerComponentConfig) (compon
 
 	inContainer := conf.Image != ""
 	var volumes []internalversion.Volume
+	var ports []internalversion.Port
 
 	if inContainer {
 		volumes = append(volumes,
@@ -115,13 +116,21 @@ func BuildKubeSchedulerComponent(conf BuildKubeSchedulerComponentConfig) (compon
 				"--bind-address="+publicAddress,
 				"--secure-port=10259",
 			)
+			if conf.Port != 0 {
+				ports = append(
+					ports,
+					internalversion.Port{
+						HostPort: conf.Port,
+						Port:     10259,
+					},
+				)
+			}
 		} else {
 			kubeSchedulerArgs = append(kubeSchedulerArgs,
 				"--bind-address="+conf.Address,
 				"--secure-port="+format.String(conf.Port),
 			)
 		}
-
 		// TODO: Support disable insecure port
 		//	kubeSchedulerArgs = append(kubeSchedulerArgs,
 		//		"--port=0",
@@ -132,6 +141,15 @@ func BuildKubeSchedulerComponent(conf BuildKubeSchedulerComponentConfig) (compon
 				"--address="+publicAddress,
 				"--port=10251",
 			)
+			if conf.Port != 0 {
+				ports = append(
+					ports,
+					internalversion.Port{
+						HostPort: conf.Port,
+						Port:     10251,
+					},
+				)
+			}
 		} else {
 			kubeSchedulerArgs = append(kubeSchedulerArgs,
 				"--address="+conf.Address,
@@ -156,6 +174,7 @@ func BuildKubeSchedulerComponent(conf BuildKubeSchedulerComponentConfig) (compon
 		Args:    kubeSchedulerArgs,
 		Binary:  conf.Binary,
 		Image:   conf.Image,
+		Ports:   ports,
 		WorkDir: conf.Workdir,
 	}, nil
 }

--- a/test/kwokctl/kwokctl_restart_test.sh
+++ b/test/kwokctl/kwokctl_restart_test.sh
@@ -54,7 +54,7 @@ function test_delete_cluster() {
 
 function test_prometheus() {
   local targets
-  for ((i = 0; i < 30; i++)); do
+  for ((i = 0; i < 60; i++)); do
     targets="$(curl -s http://127.0.0.1:9090/api/v1/targets)"
     if [[ "$(echo "${targets}" | grep -o '"health":"up"' | wc -l)" -ge 6 ]]; then
       break


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

Allow access to the kube-scheduler from the host machine

#### Which issue(s) this PR fixes:

Related to #261  (kube-scheduler-port)

