### PR TITLE
[kwokctl] Support port exposure for kube-controller-manager

### DIFF
--- a/pkg/config/vars.go
+++ b/pkg/config/vars.go
@@ -269,6 +269,8 @@ func setKwokctlKubernetesConfig(conf *v1alpha1.KwokctlConfigurationOptions) {
 	}
 	conf.KubeControllerManagerImage = envs.GetEnvWithPrefix("KUBE_CONTROLLER_MANAGER_IMAGE", conf.KubeControllerManagerImage)
 
+	conf.KubeControllerManagerPort = envs.GetEnvWithPrefix("KUBE_CONTROLLER_MANAGER_PORT", conf.KubeControllerManagerPort)
+
 	if conf.KubeSchedulerImage == "" {
 		conf.KubeSchedulerImage = joinImageURI(conf.KubeImagePrefix, "kube-scheduler", conf.KubeVersion)
 	}

--- a/pkg/kwokctl/cmd/create/cluster/cluster.go
+++ b/pkg/kwokctl/cmd/create/cluster/cluster.go
@@ -73,6 +73,7 @@ func NewCommand(ctx context.Context) *cobra.Command {
 	cmd.Flags().StringVar(&flags.Options.KubeControllerManagerImage, "kube-controller-manager-image", flags.Options.KubeControllerManagerImage, `Image of kube-controller-manager, only for docker/nerdctl runtime
 '${KWOK_KUBE_IMAGE_PREFIX}/kube-controller-manager:${KWOK_KUBE_VERSION}'
 `)
+	cmd.Flags().Uint32Var(&flags.Options.KubeControllerManagerPort, "kube-controller-manager-port", flags.Options.KubeControllerManagerPort, `Port of kube-controller-manager given to the host, only for binary and docker/nerdctl runtime`)
 	cmd.Flags().StringVar(&flags.Options.KubeSchedulerImage, "kube-scheduler-image", flags.Options.KubeSchedulerImage, `Image of kube-scheduler, only for docker/nerdctl runtime
 '${KWOK_KUBE_IMAGE_PREFIX}/kube-scheduler:${KWOK_KUBE_VERSION}'
 `)

--- a/pkg/kwokctl/components/kube_controller_manager.go
+++ b/pkg/kwokctl/components/kube_controller_manager.go
@@ -55,6 +55,7 @@ func BuildKubeControllerManagerComponent(conf BuildKubeControllerManagerComponen
 
 	inContainer := conf.Image != ""
 	var volumes []internalversion.Volume
+	var ports []internalversion.Port
 
 	if inContainer {
 		volumes = append(volumes,
@@ -95,6 +96,15 @@ func BuildKubeControllerManagerComponent(conf BuildKubeControllerManagerComponen
 				"--bind-address="+publicAddress,
 				"--secure-port=10257",
 			)
+			if conf.Port > 0 {
+				ports = append(
+					ports,
+					internalversion.Port{
+						HostPort: conf.Port,
+						Port:     10257,
+					},
+				)
+			}
 		} else {
 			kubeControllerManagerArgs = append(kubeControllerManagerArgs,
 				"--bind-address="+conf.Address,
@@ -112,6 +122,15 @@ func BuildKubeControllerManagerComponent(conf BuildKubeControllerManagerComponen
 				"--address="+publicAddress,
 				"--port=10252",
 			)
+			if conf.Port > 0 {
+				ports = append(
+					ports,
+					internalversion.Port{
+						HostPort: conf.Port,
+						Port:     10252,
+					},
+				)
+			}
 		} else {
 			kubeControllerManagerArgs = append(kubeControllerManagerArgs,
 				"--address="+conf.Address,
@@ -154,6 +173,7 @@ func BuildKubeControllerManagerComponent(conf BuildKubeControllerManagerComponen
 		Command: []string{"kube-controller-manager"},
 		Volumes: volumes,
 		Args:    kubeControllerManagerArgs,
+		Ports:   ports,
 		Binary:  conf.Binary,
 		Image:   conf.Image,
 		WorkDir: conf.Workdir,

--- a/site/content/en/docs/generated/kwokctl_create_cluster.md
+++ b/site/content/en/docs/generated/kwokctl_create_cluster.md
@@ -40,6 +40,7 @@ kwokctl create cluster [flags]
       --kube-controller-manager-image string    Image of kube-controller-manager, only for docker/nerdctl runtime
                                                 '${KWOK_KUBE_IMAGE_PREFIX}/kube-controller-manager:${KWOK_KUBE_VERSION}'
                                                  (default "registry.k8s.io/kube-controller-manager:unknown")
+      --kube-controller-manager-port uint32     Port of kube-controller-manager given to the host, only for binary and docker/nerdctl runtime
       --kube-feature-gates string               A set of key=value pairs that describe feature gates for alpha/experimental features of Kubernetes
       --kube-runtime-config string              A set of key=value pairs that enable or disable built-in APIs
       --kube-scheduler-binary string            Binary of kube-scheduler, only for binary runtime


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

Allow access to the kube-controller-manager from the host machine for binary and docker/nerdctl runtimes

#### Which issue(s) this PR fixes:

Fixes #261 

