### PR TITLE
Automated cherry pick of #400: Fixes node not initialized

### DIFF
--- a/stages/node-fast.yaml
+++ b/stages/node-fast.yaml
@@ -109,6 +109,8 @@ spec:
         operator: 'In'
         values:
           - Running
+      - key: '.status.conditions'
+        operator: 'Exists'
   delay:
     durationMilliseconds: 20000
     jitterDurationMilliseconds: 25000


### PR DESCRIPTION
Cherry pick of #400 on release-0.1.

#400: Fixes node not initialized

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note

```