### PR TITLE
Automated cherry pick of #409: Fix node controller accidental exit

### DIFF
--- a/pkg/kwok/controllers/node_controller.go
+++ b/pkg/kwok/controllers/node_controller.go
@@ -221,7 +221,6 @@ func (c *NodeController) WatchNodes(ctx context.Context, ch chan<- *corev1.Node,
 								logger.Error("Failed to lock pods on node", err,
 									"node", node.Name,
 								)
-								return
 							}
 						}
 					}


### PR DESCRIPTION
Cherry pick of #409 on release-0.1.

#409: Fix node controller accidental exit

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note

```