### PR TITLE
Automated cherry pick of #440: Fix featureGates and runtimeConfig on kind runtime

### DIFF
--- a/pkg/kwokctl/runtime/kind/kind.yaml.tpl
+++ b/pkg/kwokctl/runtime/kind/kind.yaml.tpl
@@ -77,13 +77,13 @@ nodes:
 {{ if .FeatureGates }}
 featureGates:
 {{ range .FeatureGates }}
-  {{ . }}
+  - {{ . }}
 {{ end }}
 {{ end }}
 
 {{ if .RuntimeConfig }}
 runtimeConfig:
 {{ range .RuntimeConfig }}
-  {{ . }}
+  - {{ . }}
 {{ end }}
 {{ end }}


### PR DESCRIPTION
Cherry pick of #440 on release-0.1.

#440: Fix featureGates and runtimeConfig on kind runtime

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note

```