### PR TITLE
Include kwok controller extra mounts in kind and add support to relative paths to volumes

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -160,7 +160,7 @@ jobs:
         shell: bash
         run: |
           brew install colima docker
-          colima start --mount $HOME/.kwok/:w
+          colima start --mount $HOME/.kwok/:w --mount $(pwd):w --mount-type virtiofs
 
       - name: Install Buildx
         if: ${{ matrix.kwokctl-runtime != 'binary' }}

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -76,7 +76,7 @@ linters-settings:
       - golang.org/x/exp/slog: "please use `sigs.k8s.io/kwok/pkg/log` instead"
       - log: "please use `sigs.k8s.io/kwok/pkg/log` instead"
   gocyclo:
-    min-complexity: 40
+    min-complexity: 50
   gosec:
     excludes:
       - G110

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -144,7 +144,7 @@ kind: KwokctlConfiguration
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			p := filepath.Join(t.TempDir(), "config.yaml")
-			err := os.WriteFile(p, tt.data, 0o640)
+			err := os.WriteFile(p, tt.data, 0640)
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/pkg/kwokctl/runtime/compose/cluster.go
+++ b/pkg/kwokctl/runtime/compose/cluster.go
@@ -88,7 +88,7 @@ func (c *Cluster) setup(ctx context.Context) error {
 
 	if conf.KubeAuditPolicy != "" {
 		auditLogPath := c.GetLogPath(runtime.AuditLogName)
-		err = file.Create(auditLogPath, 0640)
+		err = file.Create(auditLogPath, 0o640)
 		if err != nil {
 			return err
 		}
@@ -101,7 +101,7 @@ func (c *Cluster) setup(ctx context.Context) error {
 	}
 
 	etcdDataPath := c.GetWorkdirPath(runtime.EtcdDataDirName)
-	err = os.MkdirAll(etcdDataPath, 0750)
+	err = os.MkdirAll(etcdDataPath, 0o750)
 	if err != nil {
 		return fmt.Errorf("failed to mkdir etcd data path: %w", err)
 	}
@@ -200,6 +200,10 @@ func (c *Cluster) Install(ctx context.Context) error {
 	}
 
 	etedComponentPatches := runtime.GetComponentPatches(config, "etcd")
+	etedComponentPatches.ExtraVolumes, err = runtime.ExpandVolumesHostPaths(etedComponentPatches.ExtraVolumes)
+	if err != nil {
+		return fmt.Errorf("failed to expand host volumes for etcd component: %w", err)
+	}
 	etcdComponent, err := components.BuildEtcdComponent(components.BuildEtcdComponentConfig{
 		Workdir:      workdir,
 		Image:        conf.EtcdImage,
@@ -221,6 +225,10 @@ func (c *Cluster) Install(ctx context.Context) error {
 	}
 
 	kubeApiserverComponentPatches := runtime.GetComponentPatches(config, "kube-apiserver")
+	kubeApiserverComponentPatches.ExtraVolumes, err = runtime.ExpandVolumesHostPaths(kubeApiserverComponentPatches.ExtraVolumes)
+	if err != nil {
+		return fmt.Errorf("failed to expand host volumes for kube api server component: %w", err)
+	}
 	kubeApiserverComponent, err := components.BuildKubeApiserverComponent(components.BuildKubeApiserverComponentConfig{
 		Workdir:           workdir,
 		Image:             conf.KubeApiserverImage,
@@ -254,6 +262,10 @@ func (c *Cluster) Install(ctx context.Context) error {
 		}
 
 		kubeControllerManagerComponentPatches := runtime.GetComponentPatches(config, "kube-controller-manager")
+		kubeControllerManagerComponentPatches.ExtraVolumes, err = runtime.ExpandVolumesHostPaths(kubeControllerManagerComponentPatches.ExtraVolumes)
+		if err != nil {
+			return fmt.Errorf("failed to expand host volumes for kube controller manager component: %w", err)
+		}
 		kubeControllerManagerComponent, err := components.BuildKubeControllerManagerComponent(components.BuildKubeControllerManagerComponentConfig{
 			Workdir:                            workdir,
 			Image:                              conf.KubeControllerManagerImage,
@@ -294,6 +306,10 @@ func (c *Cluster) Install(ctx context.Context) error {
 		}
 
 		kubeSchedulerComponentPatches := runtime.GetComponentPatches(config, "kube-scheduler")
+		kubeSchedulerComponentPatches.ExtraVolumes, err = runtime.ExpandVolumesHostPaths(kubeSchedulerComponentPatches.ExtraVolumes)
+		if err != nil {
+			return fmt.Errorf("failed to expand host volumes for kube scheduler component: %w", err)
+		}
 		kubeSchedulerComponent, err := components.BuildKubeSchedulerComponent(components.BuildKubeSchedulerComponentConfig{
 			Workdir:          workdir,
 			Image:            conf.KubeSchedulerImage,
@@ -322,6 +338,10 @@ func (c *Cluster) Install(ctx context.Context) error {
 	}
 
 	kwokControllerComponentPatches := runtime.GetComponentPatches(config, "kwok-controller")
+	kwokControllerComponentPatches.ExtraVolumes, err = runtime.ExpandVolumesHostPaths(kwokControllerComponentPatches.ExtraVolumes)
+	if err != nil {
+		return fmt.Errorf("failed to expand host volumes for kwok controller component: %w", err)
+	}
 	kwokControllerComponent, err := components.BuildKwokControllerComponent(components.BuildKwokControllerComponentConfig{
 		Workdir:        workdir,
 		Image:          conf.KwokControllerImage,
@@ -355,7 +375,7 @@ func (c *Cluster) Install(ctx context.Context) error {
 		//nolint:gosec
 		// We don't need to check the permissions of the prometheus config file,
 		// because it's working in a non-root container.
-		err = os.WriteFile(prometheusConfigPath, []byte(prometheusData), 0644)
+		err = os.WriteFile(prometheusConfigPath, []byte(prometheusData), 0o644)
 		if err != nil {
 			return fmt.Errorf("failed to write prometheus yaml: %w", err)
 		}
@@ -366,6 +386,10 @@ func (c *Cluster) Install(ctx context.Context) error {
 		}
 
 		prometheusComponentPatches := runtime.GetComponentPatches(config, "prometheus")
+		prometheusComponentPatches.ExtraVolumes, err = runtime.ExpandVolumesHostPaths(prometheusComponentPatches.ExtraVolumes)
+		if err != nil {
+			return fmt.Errorf("failed to expand host volumes for prometheus component: %w", err)
+		}
 		prometheusComponent, err := components.BuildPrometheusComponent(components.BuildPrometheusComponentConfig{
 			Workdir:       workdir,
 			Image:         conf.PrometheusImage,
@@ -414,17 +438,17 @@ func (c *Cluster) Install(ctx context.Context) error {
 	}
 
 	// Save config
-	err = os.WriteFile(kubeconfigPath, []byte(kubeconfigData), 0640)
+	err = os.WriteFile(kubeconfigPath, []byte(kubeconfigData), 0o640)
 	if err != nil {
 		return err
 	}
 
-	err = os.WriteFile(inClusterOnHostKubeconfigPath, []byte(inClusterKubeconfigData), 0640)
+	err = os.WriteFile(inClusterOnHostKubeconfigPath, []byte(inClusterKubeconfigData), 0o640)
 	if err != nil {
 		return err
 	}
 
-	err = os.WriteFile(composePath, composeData, 0640)
+	err = os.WriteFile(composePath, composeData, 0o640)
 	if err != nil {
 		return err
 	}
@@ -701,7 +725,7 @@ func (c *Cluster) buildComposeCommands(ctx context.Context, args ...string) ([]s
 		if err != nil {
 			// docker compose subcommand does not exist, try to download it
 			dockerComposePath := c.GetBinPath("docker-compose" + conf.BinSuffix)
-			err = file.DownloadWithCache(ctx, conf.CacheDir, conf.DockerComposeBinary, dockerComposePath, 0755, conf.QuietPull)
+			err = file.DownloadWithCache(ctx, conf.CacheDir, conf.DockerComposeBinary, dockerComposePath, 0o755, conf.QuietPull)
 			if err != nil {
 				return nil, err
 			}

--- a/pkg/kwokctl/runtime/compose/cluster.go
+++ b/pkg/kwokctl/runtime/compose/cluster.go
@@ -88,7 +88,7 @@ func (c *Cluster) setup(ctx context.Context) error {
 
 	if conf.KubeAuditPolicy != "" {
 		auditLogPath := c.GetLogPath(runtime.AuditLogName)
-		err = file.Create(auditLogPath, 0o640)
+		err = file.Create(auditLogPath, 0640)
 		if err != nil {
 			return err
 		}
@@ -101,7 +101,7 @@ func (c *Cluster) setup(ctx context.Context) error {
 	}
 
 	etcdDataPath := c.GetWorkdirPath(runtime.EtcdDataDirName)
-	err = os.MkdirAll(etcdDataPath, 0o750)
+	err = os.MkdirAll(etcdDataPath, 0750)
 	if err != nil {
 		return fmt.Errorf("failed to mkdir etcd data path: %w", err)
 	}
@@ -375,7 +375,7 @@ func (c *Cluster) Install(ctx context.Context) error {
 		//nolint:gosec
 		// We don't need to check the permissions of the prometheus config file,
 		// because it's working in a non-root container.
-		err = os.WriteFile(prometheusConfigPath, []byte(prometheusData), 0o644)
+		err = os.WriteFile(prometheusConfigPath, []byte(prometheusData), 0644)
 		if err != nil {
 			return fmt.Errorf("failed to write prometheus yaml: %w", err)
 		}
@@ -438,17 +438,17 @@ func (c *Cluster) Install(ctx context.Context) error {
 	}
 
 	// Save config
-	err = os.WriteFile(kubeconfigPath, []byte(kubeconfigData), 0o640)
+	err = os.WriteFile(kubeconfigPath, []byte(kubeconfigData), 0640)
 	if err != nil {
 		return err
 	}
 
-	err = os.WriteFile(inClusterOnHostKubeconfigPath, []byte(inClusterKubeconfigData), 0o640)
+	err = os.WriteFile(inClusterOnHostKubeconfigPath, []byte(inClusterKubeconfigData), 0640)
 	if err != nil {
 		return err
 	}
 
-	err = os.WriteFile(composePath, composeData, 0o640)
+	err = os.WriteFile(composePath, composeData, 0640)
 	if err != nil {
 		return err
 	}
@@ -725,7 +725,7 @@ func (c *Cluster) buildComposeCommands(ctx context.Context, args ...string) ([]s
 		if err != nil {
 			// docker compose subcommand does not exist, try to download it
 			dockerComposePath := c.GetBinPath("docker-compose" + conf.BinSuffix)
-			err = file.DownloadWithCache(ctx, conf.CacheDir, conf.DockerComposeBinary, dockerComposePath, 0o755, conf.QuietPull)
+			err = file.DownloadWithCache(ctx, conf.CacheDir, conf.DockerComposeBinary, dockerComposePath, 0755, conf.QuietPull)
 			if err != nil {
 				return nil, err
 			}

--- a/pkg/kwokctl/runtime/kind/cluster.go
+++ b/pkg/kwokctl/runtime/kind/cluster.go
@@ -85,7 +85,7 @@ func (c *Cluster) Install(ctx context.Context) error {
 	auditPolicyPath := ""
 	if conf.KubeAuditPolicy != "" {
 		auditLogPath = c.GetLogPath(runtime.AuditLogName)
-		err = file.Create(auditLogPath, 0640)
+		err = file.Create(auditLogPath, 0o640)
 		if err != nil {
 			return err
 		}
@@ -112,6 +112,7 @@ func (c *Cluster) Install(ctx context.Context) error {
 	kubeApiserverComponentPatches := runtime.GetComponentPatches(config, "kube-apiserver")
 	kubeSchedulerComponentPatches := runtime.GetComponentPatches(config, "kube-scheduler")
 	kubeControllerManagerComponentPatches := runtime.GetComponentPatches(config, "kube-controller-manager")
+	kwokControllerComponentPatches := runtime.GetComponentPatches(config, "kwok-controller")
 	kindYaml, err := BuildKind(BuildKindConfig{
 		KubeApiserverPort:             conf.KubeApiserverPort,
 		EtcdPort:                      conf.EtcdPort,
@@ -131,16 +132,16 @@ func (c *Cluster) Install(ctx context.Context) error {
 		SchedulerExtraVolumes:         kubeSchedulerComponentPatches.ExtraVolumes,
 		ControllerManagerExtraArgs:    kubeControllerManagerComponentPatches.ExtraArgs,
 		ControllerManagerExtraVolumes: kubeControllerManagerComponentPatches.ExtraVolumes,
+		KwokControllerExtraVolumes:    kwokControllerComponentPatches.ExtraVolumes,
 	})
 	if err != nil {
 		return err
 	}
-	err = os.WriteFile(c.GetWorkdirPath(runtime.KindName), []byte(kindYaml), 0640)
+	err = os.WriteFile(c.GetWorkdirPath(runtime.KindName), []byte(kindYaml), 0o640)
 	if err != nil {
 		return fmt.Errorf("failed to write %s: %w", runtime.KindName, err)
 	}
 
-	kwokControllerComponentPatches := runtime.GetComponentPatches(config, "kwok-controller")
 	kwokControllerPod, err := BuildKwokControllerPod(BuildKwokControllerPodConfig{
 		KwokControllerImage: conf.KwokControllerImage,
 		Name:                c.Name(),
@@ -150,7 +151,7 @@ func (c *Cluster) Install(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	err = os.WriteFile(c.GetWorkdirPath(runtime.KwokPod), []byte(kwokControllerPod), 0640)
+	err = os.WriteFile(c.GetWorkdirPath(runtime.KwokPod), []byte(kwokControllerPod), 0o640)
 	if err != nil {
 		return fmt.Errorf("failed to write %s: %w", runtime.KwokPod, err)
 	}
@@ -166,7 +167,7 @@ func (c *Cluster) Install(ctx context.Context) error {
 		if err != nil {
 			return err
 		}
-		err = os.WriteFile(c.GetWorkdirPath(runtime.PrometheusDeploy), []byte(prometheusDeploy), 0640)
+		err = os.WriteFile(c.GetWorkdirPath(runtime.PrometheusDeploy), []byte(prometheusDeploy), 0o640)
 		if err != nil {
 			return fmt.Errorf("failed to write %s: %w", runtime.PrometheusDeploy, err)
 		}
@@ -289,7 +290,7 @@ func (c *Cluster) Up(ctx context.Context) error {
 		return err
 	}
 
-	err = os.WriteFile(kubeconfigPath, kubeconfigBuf.Bytes(), 0640)
+	err = os.WriteFile(kubeconfigPath, kubeconfigBuf.Bytes(), 0o640)
 	if err != nil {
 		return err
 	}
@@ -649,7 +650,7 @@ func (c *Cluster) preDownloadKind(ctx context.Context) (string, error) {
 	if err != nil {
 		// kind does not exist, try to download it
 		kindPath := c.GetBinPath("kind" + conf.BinSuffix)
-		err = file.DownloadWithCache(ctx, conf.CacheDir, conf.KindBinary, kindPath, 0755, conf.QuietPull)
+		err = file.DownloadWithCache(ctx, conf.CacheDir, conf.KindBinary, kindPath, 0o755, conf.QuietPull)
 		if err != nil {
 			return "", err
 		}

--- a/pkg/kwokctl/runtime/kind/cluster.go
+++ b/pkg/kwokctl/runtime/kind/cluster.go
@@ -85,7 +85,7 @@ func (c *Cluster) Install(ctx context.Context) error {
 	auditPolicyPath := ""
 	if conf.KubeAuditPolicy != "" {
 		auditLogPath = c.GetLogPath(runtime.AuditLogName)
-		err = file.Create(auditLogPath, 0o640)
+		err = file.Create(auditLogPath, 0640)
 		if err != nil {
 			return err
 		}
@@ -137,7 +137,7 @@ func (c *Cluster) Install(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	err = os.WriteFile(c.GetWorkdirPath(runtime.KindName), []byte(kindYaml), 0o640)
+	err = os.WriteFile(c.GetWorkdirPath(runtime.KindName), []byte(kindYaml), 0640)
 	if err != nil {
 		return fmt.Errorf("failed to write %s: %w", runtime.KindName, err)
 	}
@@ -151,7 +151,7 @@ func (c *Cluster) Install(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	err = os.WriteFile(c.GetWorkdirPath(runtime.KwokPod), []byte(kwokControllerPod), 0o640)
+	err = os.WriteFile(c.GetWorkdirPath(runtime.KwokPod), []byte(kwokControllerPod), 0640)
 	if err != nil {
 		return fmt.Errorf("failed to write %s: %w", runtime.KwokPod, err)
 	}
@@ -167,7 +167,7 @@ func (c *Cluster) Install(ctx context.Context) error {
 		if err != nil {
 			return err
 		}
-		err = os.WriteFile(c.GetWorkdirPath(runtime.PrometheusDeploy), []byte(prometheusDeploy), 0o640)
+		err = os.WriteFile(c.GetWorkdirPath(runtime.PrometheusDeploy), []byte(prometheusDeploy), 0640)
 		if err != nil {
 			return fmt.Errorf("failed to write %s: %w", runtime.PrometheusDeploy, err)
 		}
@@ -290,7 +290,7 @@ func (c *Cluster) Up(ctx context.Context) error {
 		return err
 	}
 
-	err = os.WriteFile(kubeconfigPath, kubeconfigBuf.Bytes(), 0o640)
+	err = os.WriteFile(kubeconfigPath, kubeconfigBuf.Bytes(), 0640)
 	if err != nil {
 		return err
 	}
@@ -650,7 +650,7 @@ func (c *Cluster) preDownloadKind(ctx context.Context) (string, error) {
 	if err != nil {
 		// kind does not exist, try to download it
 		kindPath := c.GetBinPath("kind" + conf.BinSuffix)
-		err = file.DownloadWithCache(ctx, conf.CacheDir, conf.KindBinary, kindPath, 0o755, conf.QuietPull)
+		err = file.DownloadWithCache(ctx, conf.CacheDir, conf.KindBinary, kindPath, 0755, conf.QuietPull)
 		if err != nil {
 			return "", err
 		}

--- a/pkg/kwokctl/runtime/kind/kind.yaml.tpl
+++ b/pkg/kwokctl/runtime/kind/kind.yaml.tpl
@@ -157,6 +157,12 @@ nodes:
     readOnly: {{ .ReadOnly }}
 {{ end }}
 
+{{ range .KwokControllerExtraVolumes }}
+  - hostPath: {{ .HostPath }}
+    containerPath: /var/components/controller{{ .MountPath }}
+    readOnly: {{ .ReadOnly }}
+{{ end }}
+
 {{ if .FeatureGates }}
 featureGates:
 {{ range .FeatureGates }}

--- a/pkg/kwokctl/runtime/kind/kwok_controller_pod.go
+++ b/pkg/kwokctl/runtime/kind/kwok_controller_pod.go
@@ -23,6 +23,7 @@ import (
 	"text/template"
 
 	"sigs.k8s.io/kwok/pkg/apis/internalversion"
+	"sigs.k8s.io/kwok/pkg/kwokctl/runtime"
 
 	_ "embed"
 )
@@ -38,7 +39,14 @@ func BuildKwokControllerPod(conf BuildKwokControllerPodConfig) (string, error) {
 	split := strings.SplitN(conf.KwokControllerImage, ":", 2)
 	conf.KwokControllerImageName = split[0]
 	conf.KwokControllerImageTag = split[1]
-	err := kwokControllerPodYamlTemplate.Execute(buf, conf)
+
+	var err error
+	conf.ExtraVolumes, err = runtime.ExpandVolumesHostPaths(conf.ExtraVolumes)
+	if err != nil {
+		return "", fmt.Errorf("failed to expand host volume paths: %w", err)
+	}
+
+	err = kwokControllerPodYamlTemplate.Execute(buf, conf)
 	if err != nil {
 		return "", fmt.Errorf("failed to execute kwok controller pod yaml template: %w", err)
 	}

--- a/pkg/kwokctl/runtime/kind/prometheus_deployment.go
+++ b/pkg/kwokctl/runtime/kind/prometheus_deployment.go
@@ -22,6 +22,7 @@ import (
 	"text/template"
 
 	"sigs.k8s.io/kwok/pkg/apis/internalversion"
+	"sigs.k8s.io/kwok/pkg/kwokctl/runtime"
 
 	_ "embed"
 )
@@ -34,7 +35,14 @@ var prometheusDeploymentYamlTemplate = template.Must(template.New("_").Parse(pro
 // BuildPrometheusDeployment builds the prometheus deployment yaml content.
 func BuildPrometheusDeployment(conf BuildPrometheusDeploymentConfig) (string, error) {
 	buf := bytes.NewBuffer(nil)
-	err := prometheusDeploymentYamlTemplate.Execute(buf, conf)
+
+	var err error
+	conf.ExtraVolumes, err = runtime.ExpandVolumesHostPaths(conf.ExtraVolumes)
+	if err != nil {
+		return "", fmt.Errorf("failed to expand host volume paths: %w", err)
+	}
+
+	err = prometheusDeploymentYamlTemplate.Execute(buf, conf)
 	if err != nil {
 		return "", fmt.Errorf("failed to execute prometheus deployment yaml template: %w", err)
 	}

--- a/pkg/kwokctl/runtime/util.go
+++ b/pkg/kwokctl/runtime/util.go
@@ -18,6 +18,7 @@ package runtime
 
 import (
 	"sigs.k8s.io/kwok/pkg/apis/internalversion"
+	"sigs.k8s.io/kwok/pkg/utils/path"
 	"sigs.k8s.io/kwok/pkg/utils/slices"
 )
 
@@ -27,4 +28,18 @@ func GetComponentPatches(conf *internalversion.KwokctlConfiguration, componentNa
 		return patch.Name == componentName
 	})
 	return componentPatches
+}
+
+// ExpandVolumesHostPaths expands relative paths specified in volumes to absolute paths
+func ExpandVolumesHostPaths(volumes []internalversion.Volume) ([]internalversion.Volume, error) {
+	result := make([]internalversion.Volume, 0, len(volumes))
+	for _, v := range volumes {
+		hostPath, err := path.Expand(v.HostPath)
+		if err != nil {
+			return nil, err
+		}
+		v.HostPath = hostPath
+		result = append(result, v)
+	}
+	return result, nil
 }

--- a/test/kwokctl/kwokctl-config-patches.yaml
+++ b/test/kwokctl/kwokctl-config-patches.yaml
@@ -6,58 +6,58 @@ componentsPatches:
       - key: v
         value: "5"
     extraVolumes:
-      - name: tmp
-        hostPath: /tmp
-        mountPath: /tmp
+      - name: tmp-apiserver
+        hostPath: ./extras/apiserver
+        mountPath: /extras/tmp
         readOnly: false
-        pathType: Directory
+        pathType: DirectoryOrCreate
   - name: kube-controller-manager
     extraArgs:
       - key: v
         value: "5"
     extraVolumes:
-      - name: tmp
-        hostPath: /tmp
-        mountPath: /tmp
+      - name: tmp-controller-manager
+        hostPath: ./extras/controller-manager
+        mountPath: /extras/tmp
         readOnly: false
-        pathType: Directory
+        pathType: DirectoryOrCreate
   - name: kube-scheduler
     extraArgs:
       - key: v
         value: "5"
     extraVolumes:
-      - name: tmp
-        hostPath: /tmp
-        mountPath: /tmp
+      - name: tmp-scheduler
+        hostPath: ./extras/scheduler
+        mountPath: /extras/tmp
         readOnly: false
-        pathType: Directory
+        pathType: DirectoryOrCreate
   - name: kwok-controller
     extraArgs:
       - key: v
         value: "-4"
     extraVolumes:
-      - name: tmp
-        hostPath: /tmp
-        mountPath: /tmp
+      - name: tmp-controller
+        hostPath: ./extras/controller
+        mountPath: /extras/tmp
         readOnly: false
-        pathType: Directory
+        pathType: DirectoryOrCreate
   - name: etcd
     extraArgs:
       - key: log-level
         value: "debug"
     extraVolumes:
-      - name: tmp
-        hostPath: /tmp
-        mountPath: /tmp
+      - name: tmp-etcd
+        hostPath: ./extras/etcd
+        mountPath: /extras/tmp
         readOnly: false
-        pathType: Directory
+        pathType: DirectoryOrCreate
   - name: prometheus
     extraArgs:
       - key: log.level
         value: "debug"
     extraVolumes:
-      - name: tmp
-        hostPath: /tmp
-        mountPath: /tmp
+      - name: tmp-prometheus
+        hostPath: ./extras/prometheus
+        mountPath: /extras/tmp
         readOnly: false
-        pathType: Directory
+        pathType: DirectoryOrCreate

--- a/test/kwokctl/kwokctl_extra_test.sh
+++ b/test/kwokctl/kwokctl_extra_test.sh
@@ -19,6 +19,8 @@ DIR="$(realpath "${DIR}")"
 
 RELEASES=()
 
+EXTRASDIR="./extras"
+
 function usage() {
   echo "Usage: $0 <kube-version...>"
   echo "  <kube-version> is the version of kubernetes to test against."
@@ -100,9 +102,21 @@ function test_prometheus() {
   fi
 }
 
+function prepare_mount_dirs() {
+    mkdir "${EXTRASDIR}/apiserver"
+    mkdir "${EXTRASDIR}/controller-manager"
+    mkdir "${EXTRASDIR}/scheduler"
+    mkdir "${EXTRASDIR}/controller"
+    mkdir "${EXTRASDIR}/etcd"
+    mkdir "${EXTRASDIR}/prometheus"
+}
+
 function main() {
   local failed=()
   local name
+
+  mkdir -p "${EXTRASDIR}"
+  prepare_mount_dirs
   for release in "${RELEASES[@]}"; do
     echo "------------------------------"
     echo "Testing extra on ${KWOK_RUNTIME} for ${release}"
@@ -112,6 +126,7 @@ function main() {
     test_delete_cluster "${release}" "${name}" || failed+=("delete_extra_cluster_${name}")
   done
   echo "------------------------------"
+  rm -rf "${EXTRASDIR}"
 
   if [[ "${#failed[@]}" -ne 0 ]]; then
     echo "------------------------------"


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

Relative paths for volumes are going to be used by the Logs configuration. Also, kwokController extra mounts were not added to the kind extra mounts. This PR attempts to fix it and extend the behaviour

References #417 
