### PR TITLE
snapshot: add limitrange, priorityclass and runtimeclass to default resources

### DIFF
--- a/pkg/kwokctl/snapshot/runtime.go
+++ b/pkg/kwokctl/snapshot/runtime.go
@@ -25,12 +25,19 @@ import (
 )
 
 // Resources is the resources of cluster want to save or restore
+// The resource string format adheres to a GVR template.
+// - a single string like "node" will be parsed as {resource: node}
+// - a two-section string like "daemonset.apps" will be parsed as {resource: dasemonset, group: apps}
+// - a three-section (or 3+) string like "foo.v1alpha1.example.com" will be parsed as {resource: foo, version: v1alpha1, group: example.com}
 var Resources = []string{
 	"namespace",
 	"node",
 	"serviceaccount",
 	"configmap",
 	"secret",
+	"limitrange",
+	"runtimeclass.node.k8s.io",
+	"priorityclass.scheduling.k8s.io",
 	"daemonset.apps",
 	"deployment.apps",
 	"replicaset.apps",

--- a/site/content/en/docs/generated/kwokctl_snapshot_export.md
+++ b/site/content/en/docs/generated/kwokctl_snapshot_export.md
@@ -9,7 +9,7 @@ kwokctl snapshot export [flags]
 ### Options
 
 ```
-      --filter strings      Filter the resources to export (default [namespace,node,serviceaccount,configmap,secret,daemonset.apps,deployment.apps,replicaset.apps,statefulset.apps,cronjob.batch,job.batch,persistentvolumeclaim,persistentvolume,pod,service,endpoints])
+      --filter strings      Filter the resources to export (default [namespace,node,serviceaccount,configmap,secret,limitrange,runtimeclass.node.k8s.io,priorityclass.scheduling.k8s.io,daemonset.apps,deployment.apps,replicaset.apps,statefulset.apps,cronjob.batch,job.batch,persistentvolumeclaim,persistentvolume,pod,service,endpoints])
   -h, --help                help for export
       --kubeconfig string   Path to the kubeconfig file to use
       --path string         Path to the snapshot

--- a/site/content/en/docs/generated/kwokctl_snapshot_restore.md
+++ b/site/content/en/docs/generated/kwokctl_snapshot_restore.md
@@ -9,7 +9,7 @@ kwokctl snapshot restore [flags]
 ### Options
 
 ```
-      --filter strings   Filter the resources to restore, only support for k8s format (default [namespace,node,serviceaccount,configmap,secret,daemonset.apps,deployment.apps,replicaset.apps,statefulset.apps,cronjob.batch,job.batch,persistentvolumeclaim,persistentvolume,pod,service,endpoints])
+      --filter strings   Filter the resources to restore, only support for k8s format (default [namespace,node,serviceaccount,configmap,secret,limitrange,runtimeclass.node.k8s.io,priorityclass.scheduling.k8s.io,daemonset.apps,deployment.apps,replicaset.apps,statefulset.apps,cronjob.batch,job.batch,persistentvolumeclaim,persistentvolume,pod,service,endpoints])
       --format string    Format of the snapshot file (etcd, k8s) (default "etcd")
   -h, --help             help for restore
       --path string      Path to the snapshot

--- a/site/content/en/docs/generated/kwokctl_snapshot_save.md
+++ b/site/content/en/docs/generated/kwokctl_snapshot_save.md
@@ -9,7 +9,7 @@ kwokctl snapshot save [flags]
 ### Options
 
 ```
-      --filter strings   Filter the resources to save, only support for k8s format (default [namespace,node,serviceaccount,configmap,secret,daemonset.apps,deployment.apps,replicaset.apps,statefulset.apps,cronjob.batch,job.batch,persistentvolumeclaim,persistentvolume,pod,service,endpoints])
+      --filter strings   Filter the resources to save, only support for k8s format (default [namespace,node,serviceaccount,configmap,secret,limitrange,runtimeclass.node.k8s.io,priorityclass.scheduling.k8s.io,daemonset.apps,deployment.apps,replicaset.apps,statefulset.apps,cronjob.batch,job.batch,persistentvolumeclaim,persistentvolume,pod,service,endpoints])
       --format string    Format of the snapshot file (etcd, k8s) (default "etcd")
   -h, --help             help for save
       --path string      Path to the snapshot


### PR DESCRIPTION

#### What type of PR is this?

/kind cleanup
/kind documentation

#### What this PR does / why we need it:

In regular prod clusters, usually namespace is associated with LimitRange, and Pods are associated with RuntimeClass and PriorityClass. Not scraping them by default would cause the snapshot infeasible to be imported/restored.

Also this PR explains how a resource string is parsed to a GVR object.

#### Which issue(s) this PR fixes:

Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
