### PR TITLE
snapshot: add --as and --as-group to support impersonation

### DIFF
--- a/pkg/kwokctl/runtime/cluster_snapshot.go
+++ b/pkg/kwokctl/runtime/cluster_snapshot.go
@@ -21,6 +21,8 @@ import (
 	"context"
 	"os"
 
+	"k8s.io/client-go/rest"
+
 	"sigs.k8s.io/kwok/pkg/kwokctl/snapshot"
 )
 
@@ -34,7 +36,9 @@ func (c *Cluster) SnapshotSaveWithYAML(ctx context.Context, path string, filters
 		_ = file.Close()
 	}()
 	kubeconfigPath := c.GetWorkdirPath(InHostKubeconfigName)
-	return snapshot.Save(ctx, kubeconfigPath, file, filters)
+	// In most cases, the user should have full privileges on the clusters created by kwokctl,
+	// so no need to expose impersonation args to "snapshot save" command.
+	return snapshot.Save(ctx, kubeconfigPath, file, filters, rest.ImpersonationConfig{})
 }
 
 // SnapshotRestoreWithYAML restore the snapshot of cluster

--- a/pkg/kwokctl/snapshot/save.go
+++ b/pkg/kwokctl/snapshot/save.go
@@ -27,6 +27,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/util/net"
 	"k8s.io/client-go/dynamic"
+	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/pager"
 	"k8s.io/client-go/util/retry"
 
@@ -35,12 +36,13 @@ import (
 )
 
 // Save saves the snapshot of cluster
-func Save(ctx context.Context, kubeconfigPath string, w io.Writer, resources []string) error {
+func Save(ctx context.Context, kubeconfigPath string, w io.Writer, resources []string, impersonateConfig rest.ImpersonationConfig) error {
 	clientset, err := client.NewClientset("", kubeconfigPath)
 	if err != nil {
 		return fmt.Errorf("failed to create clientset: %w", err)
 	}
 	restConfig, err := clientset.ToRESTConfig()
+	restConfig.Impersonate = impersonateConfig
 	if err != nil {
 		return fmt.Errorf("failed to get rest config: %w", err)
 	}

--- a/site/content/en/docs/generated/kwokctl_snapshot_export.md
+++ b/site/content/en/docs/generated/kwokctl_snapshot_export.md
@@ -9,6 +9,8 @@ kwokctl snapshot export [flags]
 ### Options
 
 ```
+      --as string           Username to impersonate for the operation. User could be a regular user or a service account in a namespace.
+      --as-group strings    Group to impersonate for the operation, this flag can be repeated to specify multiple groups.
       --filter strings      Filter the resources to export (default [namespace,node,serviceaccount,configmap,secret,limitrange,runtimeclass.node.k8s.io,priorityclass.scheduling.k8s.io,daemonset.apps,deployment.apps,replicaset.apps,statefulset.apps,cronjob.batch,job.batch,persistentvolumeclaim,persistentvolume,pod,service,endpoints])
   -h, --help                help for export
       --kubeconfig string   Path to the kubeconfig file to use


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

kubectl supports impersonation to uplift the default serviceaccount's privileges to operate some resources. Without populating this in `snapshot export`, users would be halted when scraping some resources like `secret`:

```console
$ go run ./cmd/kwokctl/main.go snapshot export --kubeconfig /Users/weih/.kube/config --path /tmp/secret
ERROR Execute exit err="failed to list resource \"secrets\": secrets is forbidden: User \"xyz\" cannot list resource \"secrets\" in API group \"\" at the cluster scope"
exit status 1
```

This PR adds the support of `--as` and `--as-group`:

```console
$ go run ./cmd/kwokctl/main.go snapshot export --kubeconfig /Users/weih/.kube/config --path /tmp/secret1 --as <user> --as-group <group>
```

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
- https://kubernetes.io/docs/reference/access-authn-authz/authentication/
```
