### PR TITLE
Automated cherry pick of #542: Fix error template value for node-fast.yaml

### DIFF
--- a/stages/node-fast.yaml
+++ b/stages/node-fast.yaml
@@ -73,7 +73,7 @@ spec:
         machineID: {{ with .machineID }} {{ . }} {{ else }} "" {{ end }}
         operatingSystem: {{ with .operatingSystem }} {{ . }} {{ else }} "linux" {{ end }}
         osImage: {{ with .osImage }} {{ . }} {{ else }} "" {{ end }}
-        systemUUID: {{ with .osImage }} {{ . }} {{ else }} "" {{ end }}
+        systemUUID: {{ with .systemUUID }} {{ . }} {{ else }} "" {{ end }}
       {{ end }}
       phase: Running
   immediateNextStage: true


### PR DESCRIPTION
Cherry pick of #542 on release-0.2.

#542: Fix error template value for node-fast.yaml

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note
NONE
```