### PR TITLE
Add verify-spelling.sh for English words.

### DIFF
--- a/hack/spelling.txt
+++ b/hack/spelling.txt
@@ -1,0 +1,1 @@
+importas

--- a/hack/update-all.sh
+++ b/hack/update-all.sh
@@ -51,6 +51,11 @@ if [[ "${UPDATE_SHELL_FORMAT:-true}" == "true" ]]; then
   "${ROOT_DIR}"/hack/update-shell-format.sh || failed+=(shell-format)
 fi
 
+if [[ "${UPDATE_SPELLING:-true}" == "true" ]]; then
+  echo "[*] Update spelling..."
+  "${ROOT_DIR}"/hack/update-spelling.sh || failed+=(spelling)
+fi
+
 if [[ "${#failed[@]}" != 0 ]]; then
   echo "Update failed for: ${failed[*]}"
   exit 1

--- a/hack/update-spelling.sh
+++ b/hack/update-spelling.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+# Copyright 2023 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+TOOL_VERSION="v0.3.4"
+
+ROOT_DIR="$(realpath "$(dirname "${BASH_SOURCE[0]}")"/..)"
+allowed_spelling_words="${ROOT_DIR}/hack/spelling.txt"
+
+COMMAND=()
+if command -v misspell; then
+  COMMAND=(misspell)
+elif command -v "${ROOT_DIR}/bin/misspell"; then
+  COMMAND=("${ROOT_DIR}/bin/misspell")
+else
+  GOBIN="${ROOT_DIR}/bin/" go install github.com/client9/misspell/cmd/misspell@${TOOL_VERSION}
+  COMMAND=("${ROOT_DIR}/bin/misspell")
+fi
+
+function update() {
+  local ignore
+  ignore="$(tr <"${allowed_spelling_words}" '\n' ',')"
+  mapfile -t files < <(find . \( \
+    -iname "*.md" -o \
+    -iname "*.sh" -o \
+    -iname "*.go" -o \
+    -iname "*.tpl" -o \
+    -iname "*.yaml" -o \
+    -iname "*.yml" \
+    \) \
+    -not \( \
+    -path ./.git/\* -o \
+    -path ./vendor/\* -o \
+    -path ./demo/node_modules/\* -o \
+    -path ./site/themes/\* \
+    \))
+  "${COMMAND[@]}" -locale US -w -i "${ignore}" "${files[@]}"
+}
+
+cd "${ROOT_DIR}"
+update || exit 1

--- a/hack/verify-all.sh
+++ b/hack/verify-all.sh
@@ -66,6 +66,11 @@ if [[ "${VERIFY_SHELL_FORMAT:-true}" == "true" ]]; then
   "${ROOT_DIR}"/hack/verify-shell-format.sh || failed+=(shell-format)
 fi
 
+if [[ "${VERIFY_SPELLING:-true}" == "true" ]]; then
+  echo "[*] Verifying spelling..."
+  "${ROOT_DIR}"/hack/verify-spelling.sh || failed+=(spelling)
+fi
+
 # exit based on verify scripts
 if [[ "${#failed[@]}" != 0 ]]; then
   echo "Verify failed for: ${failed[*]}"

--- a/hack/verify-spelling.sh
+++ b/hack/verify-spelling.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+# Copyright 2023 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+ROOT_DIR="$(realpath "$(dirname "${BASH_SOURCE[0]}")"/..)"
+
+function check() {
+  echo "Verify spelling"
+  "${ROOT_DIR}"/hack/update-spelling.sh
+  git --no-pager diff --exit-code
+}
+
+cd "${ROOT_DIR}"
+check || exit 1

--- a/pkg/kwok/server/debugging_logs.go
+++ b/pkg/kwok/server/debugging_logs.go
@@ -535,7 +535,7 @@ func waitLogs(ctx context.Context, watcher *fsnotify.Watcher) (bool, bool, error
 	for {
 		select {
 		case <-ctx.Done():
-			return false, false, fmt.Errorf("context cancelled")
+			return false, false, fmt.Errorf("context canceled")
 		case e := <-watcher.Events:
 			switch e.Op {
 			case fsnotify.Write:

--- a/pkg/log/logger_ctl.go
+++ b/pkg/log/logger_ctl.go
@@ -113,7 +113,7 @@ func (c *ctlHandler) Handle(r slog.Record) error {
 	if attrsStr == "" {
 		if r.Level != slog.InfoLevel {
 			levelStr := r.Level.String()
-			c, ok := levelColour[strings.SplitN(levelStr, "+", 2)[0]]
+			c, ok := levelColor[strings.SplitN(levelStr, "+", 2)[0]]
 			if ok {
 				msg = c.renderer + " " + msg
 			}
@@ -123,7 +123,7 @@ func (c *ctlHandler) Handle(r slog.Record) error {
 		msgWidth := stringWidth(msg)
 		if r.Level != slog.InfoLevel {
 			levelStr := r.Level.String()
-			c, ok := levelColour[strings.SplitN(levelStr, "+", 2)[0]]
+			c, ok := levelColor[strings.SplitN(levelStr, "+", 2)[0]]
 			if ok {
 				msg = c.renderer + " " + msg
 				msgWidth += c.width + 1
@@ -139,19 +139,19 @@ func (c *ctlHandler) Handle(r slog.Record) error {
 	return err
 }
 
-type colour struct {
+type color struct {
 	renderer string
 	width    int
 }
 
-func newColour(c ctc.Color, msg string) colour {
-	return colour{
+func newColour(c ctc.Color, msg string) color {
+	return color{
 		renderer: fmt.Sprintf("%s%s%s", c, msg, ctc.Reset),
 		width:    stringWidth(msg),
 	}
 }
 
-var levelColour = map[string]colour{
+var levelColor = map[string]color{
 	slog.ErrorLevel.String(): newColour(ctc.ForegroundRed, slog.ErrorLevel.String()),
 	slog.WarnLevel.String():  newColour(ctc.ForegroundYellow, slog.WarnLevel.String()),
 	slog.DebugLevel.String(): newColour(ctc.ForegroundCyan, slog.DebugLevel.String()),


### PR DESCRIPTION
#### What type of PR is this?
/kind feature

#### What this PR does / why we need it:
Add verify-spelling.sh to check english typos...

Ignore .golangci.yaml, 
```
./.golangci.yaml:22:6: "importas" is a misspelling of "imports"
./.golangci.yaml:50:2: "importas" is a misspelling of "imports"
```
because importas is the package name.
[golinters importas typos](https://github.com/golangci/golangci-lint/blob/cbc3a0c70ec14f15612caa056a805e229d64a529/pkg/golinters/importas.go#L7)

#### Which issue(s) this PR fixes:
Fixes #545

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
None
```

