### PR TITLE
Automated cherry pick of #551: Fix hugo version check

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -14,6 +14,15 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  check-site:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Check site
+        shell: bash
+        run: |
+          make -C site check
+
   test-build:
     runs-on: ubuntu-latest
     strategy:
@@ -32,11 +41,6 @@ jobs:
         shell: bash
         run: |
           ./hack/e2e-test.sh release/build
-
-      - name: Check site
-        shell: bash
-        run: |
-          make -C site check
 
       - name: Build
         shell: bash

--- a/site/Makefile
+++ b/site/Makefile
@@ -40,11 +40,11 @@ check-version: check-binary-version check-image-version
 
 .PHONY: check-image-version
 check-image-version:
-	docker manifest inspect $(HUGO_IMAGE)
+	skopeo --override-os linux inspect docker://$(HUGO_IMAGE)
 
 .PHONY: check-binary-version
 check-binary-version:
-	curl -sL https://api.github.com/repos/gohugoio/hugo/releases/tags/v$(HUGO_VERSION)
+	curl -sfL https://api.github.com/repos/gohugoio/hugo/releases/tags/v$(HUGO_VERSION)
 
 .PHONY: links
 links:


### PR DESCRIPTION
Cherry pick of #551 on release-0.2.

#551: Fix hugo version check

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note
NONE
```