### PR TITLE
fix verify-ends-newline

### DIFF
--- a/hack/verify-ends-newline.sh
+++ b/hack/verify-ends-newline.sh
@@ -28,6 +28,12 @@ function check_ends() {
     -o -iname "*.yaml" \
     -o -iname "*.yml" \
     \) \
+    -not \( \
+    -path ./.git/\* -o \
+    -path ./vendor/\* -o \
+    -path ./demo/node_modules/\* -o \
+    -path ./site/themes/\* \
+    \) \
     -exec sh -c '[ -n "$(tail -c 1 "$1")" ] && echo "$1"' sh {} \;
 }
 


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

This PR adds the option to exclude files in the vendor directory when using the check_ends function. 

This ensures that files in the vendor directory are not mistakenly included in the check for newline characters at the end of files. 

#### Which issue(s) this PR fixes:

Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs

```
