### PR TITLE
fix authorization-always-allow-paths for kube-scheduler

### DIFF
--- a/pkg/kwokctl/components/kube_scheduler.go
+++ b/pkg/kwokctl/components/kube_scheduler.go
@@ -107,7 +107,7 @@ func BuildKubeSchedulerComponent(conf BuildKubeSchedulerComponentConfig) (compon
 	}
 
 	if conf.SecurePort {
-		if conf.Version.GE(version.NewVersion(1, 12, 0)) {
+		if conf.Version.GE(version.NewVersion(1, 13, 0)) {
 			kubeSchedulerArgs = append(kubeSchedulerArgs,
 				"--authorization-always-allow-paths=/healthz,/readyz,/livez,/metrics",
 			)


### PR DESCRIPTION

#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

fix authorization-always-allow-paths for kube-scheduler

#### Which issue(s) this PR fixes:

Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs

```
