### PR TITLE
disable secure-port before Kubernetes 1.13.0

### DIFF
--- a/pkg/apis/config/v1alpha1/kwokctl_configuration_types.go
+++ b/pkg/apis/config/v1alpha1/kwokctl_configuration_types.go
@@ -109,6 +109,7 @@ type KwokctlConfigurationOptions struct {
 	KindVersion string `json:"kindVersion,omitempty"`
 
 	// SecurePort is the apiserver port on which to serve HTTPS with authentication and authorization.
+	// is not available before Kubernetes 1.13.0
 	// is the default value for flag --secure-port and env KWOK_SECURE_PORT
 	SecurePort *bool `json:"securePort,omitempty"`
 

--- a/pkg/apis/internalversion/kwokctl_configuration_types.go
+++ b/pkg/apis/internalversion/kwokctl_configuration_types.go
@@ -87,6 +87,7 @@ type KwokctlConfigurationOptions struct {
 	KindVersion string
 
 	// SecurePort is the apiserver port on which to serve HTTPS with authentication and authorization.
+	// is not available before Kubernetes 1.13.0
 	SecurePort bool
 
 	// QuietPull is the flag to quiet the pull.

--- a/pkg/kwokctl/cmd/create/cluster/cluster.go
+++ b/pkg/kwokctl/cmd/create/cluster/cluster.go
@@ -62,7 +62,7 @@ func NewCommand(ctx context.Context) *cobra.Command {
 
 	cmd.Flags().Uint32Var(&flags.Options.KubeApiserverPort, "kube-apiserver-port", flags.Options.KubeApiserverPort, `Port of the apiserver (default random)`)
 	cmd.Flags().Uint32Var(&flags.Options.PrometheusPort, "prometheus-port", flags.Options.PrometheusPort, `Port to expose Prometheus metrics`)
-	cmd.Flags().BoolVar(&flags.Options.SecurePort, "secure-port", flags.Options.SecurePort, `The apiserver port on which to serve HTTPS with authentication and authorization`)
+	cmd.Flags().BoolVar(&flags.Options.SecurePort, "secure-port", flags.Options.SecurePort, `The apiserver port on which to serve HTTPS with authentication and authorization, is not available before Kubernetes 1.13.0`)
 	cmd.Flags().BoolVar(&flags.Options.QuietPull, "quiet-pull", flags.Options.QuietPull, `Pull without printing progress information`)
 	cmd.Flags().StringVar(&flags.Options.KubeSchedulerConfig, "kube-scheduler-config", flags.Options.KubeSchedulerConfig, `Path to a kube-scheduler configuration file`)
 	cmd.Flags().BoolVar(&flags.Options.DisableKubeScheduler, "disable-kube-scheduler", flags.Options.DisableKubeScheduler, `Disable the kube-scheduler`)

--- a/pkg/kwokctl/components/kube_controller_manager.go
+++ b/pkg/kwokctl/components/kube_controller_manager.go
@@ -103,7 +103,7 @@ func BuildKubeControllerManagerComponent(conf BuildKubeControllerManagerComponen
 	}
 
 	if conf.SecurePort {
-		if conf.Version.GE(version.NewVersion(1, 12, 0)) {
+		if conf.Version.GE(version.NewVersion(1, 13, 0)) {
 			kubeControllerManagerArgs = append(kubeControllerManagerArgs,
 				"--authorization-always-allow-paths=/healthz,/readyz,/livez,/metrics",
 			)

--- a/pkg/kwokctl/components/kube_scheduler.go
+++ b/pkg/kwokctl/components/kube_scheduler.go
@@ -107,7 +107,7 @@ func BuildKubeSchedulerComponent(conf BuildKubeSchedulerComponentConfig) (compon
 	}
 
 	if conf.SecurePort {
-		if conf.Version.GE(version.NewVersion(1, 12, 0)) {
+		if conf.Version.GE(version.NewVersion(1, 13, 0)) {
 			kubeSchedulerArgs = append(kubeSchedulerArgs,
 				"--authorization-always-allow-paths=/healthz,/readyz,/livez,/metrics",
 			)

--- a/site/content/en/docs/generated/kwokctl_create_cluster.md
+++ b/site/content/en/docs/generated/kwokctl_create_cluster.md
@@ -66,7 +66,7 @@ kwokctl create cluster [flags]
       --prometheus-port uint32                  Port to expose Prometheus metrics
       --quiet-pull                              Pull without printing progress information
       --runtime string                          Runtime of the cluster (binary or docker or kind or kind-podman or nerdctl or podman)
-      --secure-port                             The apiserver port on which to serve HTTPS with authentication and authorization (default true)
+      --secure-port                             The apiserver port on which to serve HTTPS with authentication and authorization, is not available before Kubernetes 1.13.0 (default true)
       --timeout duration                        Timeout for waiting for the cluster to be created
       --wait duration                           Wait for the cluster to be ready
 ```


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

`kube-scheduler 1.12.10` does not support the following flags:

- `--authorization-always-allow-paths`
- `--secure-port`
- `--bind-address`

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note

```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
