### PR TITLE
fix update-end-newline

### DIFF
--- a/hack/update-ends-newline.sh
+++ b/hack/update-ends-newline.sh
@@ -28,7 +28,13 @@ function update_ends_newline() {
     -o -iname "*.yaml" \
     -o -iname "*.yml" \
     \) \
-    -exec sh -c '[ -n "$(tail -c 1 "$1")" ] && echo "$1"' sh {} \;
+    -not \( \
+    -path ./.git/\* -o \
+    -path ./vendor/\* -o \
+    -path ./demo/node_modules/\* -o \
+    -path ./site/themes/\* \
+    \) \
+    -exec sh -c '[ -n "$(tail -c 1 $1)" ] && echo >> $1' sh {} \;
 }
 
 cd "${ROOT_DIR}"


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

The original script does not update the files without newline in the end of the file.

#### Which issue(s) this PR fixes:

Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs

```
