### PR TITLE
fix exec broken pipe error

### DIFF
--- a/test/kwokctl/kwokctl_exec_test.sh
+++ b/test/kwokctl/kwokctl_exec_test.sh
@@ -44,8 +44,9 @@ function test_exec() {
   local cmd="${4}"
   local want="${5}"
   local result
-  for ((i = 0; i < 120; i++)); do
-    if result=$(kwokctl --name "${name}" kubectl -n "${namespace}" exec -i "${target}" -- "${cmd}"); then
+  for ((i = 0; i < 10; i++)); do
+    result=$(kwokctl --name "${name}" kubectl -n "${namespace}" exec -i "${target}" -- "${cmd}" || :)
+    if [[ "${result}" == *"${want}"* ]]; then
       break
     fi
     sleep 1


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

The test cases for `exec` sometimes encounter a "broken pipe" error, so a retry mechanism has been added.

Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs

```
