### PR TITLE
check go-format in dir hack & stages

### DIFF
--- a/hack/update-go-format.sh
+++ b/hack/update-go-format.sh
@@ -21,5 +21,5 @@ REPO_ROOT=$(dirname "${BASH_SOURCE[0]}")/..
 
 cd "${REPO_ROOT}"
 
-mapfile -t gofiles < <(find cmd pkg -name '*.go')
+mapfile -t gofiles < <(find cmd pkg hack stages -name '*.go')
 gofmt -s -w "${gofiles[@]}"

--- a/hack/verify-go-format.sh
+++ b/hack/verify-go-format.sh
@@ -21,7 +21,7 @@ ROOT_DIR="$(dirname "${BASH_SOURCE[0]}")/.."
 
 function check() {
   echo "Verify gofmt"
-  mapfile -t findfiles < <(find cmd pkg -name '*.go')
+  mapfile -t findfiles < <(find cmd pkg hack stages -name '*.go')
   out="$(gofmt -s -w "${findfiles[@]}")"
 
   if [[ -n "${out}" ]]; then


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

go-format's check didn't cover dirs hack & stages.

#### Which issue(s) this PR fixes:

Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
