### PR TITLE
pkg/kwok/controllers: should not add duplicate job

### DIFF
--- a/kustomize/rbac/role.yaml
+++ b/kustomize/rbac/role.yaml
@@ -7,6 +7,18 @@ rules:
 - apiGroups:
   - ""
   resources:
+  - events
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - ""
+  resources:
   - nodes
   verbs:
   - get

--- a/pkg/apis/v1alpha1/doc.go
+++ b/pkg/apis/v1alpha1/doc.go
@@ -22,6 +22,7 @@ limitations under the License.
 // +kubebuilder:rbac:groups="",resources=nodes/status,verbs=patch;update
 // +kubebuilder:rbac:groups="",resources=pods,verbs=delete;get;list;patch;update;watch
 // +kubebuilder:rbac:groups="",resources=pods/status,verbs=patch;update
+// +kubebuilder:rbac:groups="",resources=events,verbs=create;delete;get;list;patch;update;watch
 // +kubebuilder:rbac:groups=coordination.k8s.io,resources=leases,verbs=create;get;list;patch;update;watch
 
 // Package v1alpha1 implements the v1alpha1 apiVersion of kwok's configuration


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

When kube-apiserver restarts, the watch might return ADD event which we already received.
We should not add the cronjob for the same node. Otherwise, the number of lease updates will be increased 2-3 times.


#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note

```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
