### PR TITLE
pkg/kwok/controllers: use informer for NodeLeaseController

### DIFF
--- a/pkg/kwok/controllers/node_lease_controller.go
+++ b/pkg/kwok/controllers/node_lease_controller.go
@@ -276,7 +276,7 @@ func (c *NodeLeaseController) sync(ctx context.Context, name string) {
 	}
 
 	logger.Info("Syncing lease")
-	lease, transitions, err := c.renewLease(ctx, lease)
+	_, transitions, err := c.renewLease(ctx, lease)
 	if err != nil {
 		logger.Error("failed to update lease using latest lease", err)
 		return


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup


#### What this PR does / why we need it:

With high pressure, the kube-apiserver might restart because of OOM. Current design uses Watch without bookmark revision and it might receive old the data. The client-go informer can help us to refresh existing cache, instead of building our own component to refresh or ignored old version of data.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note

```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
