### PR TITLE
Makefile: cleanup unused vendor code

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -84,12 +84,9 @@ DOCKER_CLI_EXPERIMENTAL ?= enabled
 .PHONY: default
 default: help
 
-vendor:
-	@$(GO_CMD) mod vendor
-
 ## unit-test: Run unit tests
 .PHONY: unit-test
-unit-test: vendor
+unit-test:
 	@$(GO_CMD) test ./pkg/...
 
 ## verify: Verify code
@@ -104,7 +101,7 @@ update:
 
 ## build: Build binary
 .PHONY: build
-build: vendor
+build:
 	@./hack/releases.sh \
 		$(addprefix --bin=, $(BINARY)) \
 		$(addprefix --extra-tag=, $(EXTRA_TAGS)) \
@@ -148,7 +145,7 @@ endif
 
 ## cross-build: Build kwok and kwokctl for all supported platforms
 .PHONY: cross-build
-cross-build: vendor
+cross-build:
 	@./hack/releases.sh \
 		$(addprefix --bin=, $(BINARY)) \
 		$(addprefix --platform=, $(BINARY_PLATFORMS)) \


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup


#### What this PR does / why we need it:

Since we have gitignore vendor, it's safe to delete the vendor recipe in Makefile.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note

```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
