### PR TITLE
fix(kwokctl): modify misunderstanding description in config subcommand

### DIFF
--- a/pkg/kwokctl/cmd/config/tidy/tidy.go
+++ b/pkg/kwokctl/cmd/config/tidy/tidy.go
@@ -33,7 +33,7 @@ func NewCommand(ctx context.Context) *cobra.Command {
 	cmd := &cobra.Command{
 		Args:  cobra.NoArgs,
 		Use:   "tidy",
-		Short: "Tidy the default config file with --config",
+		Short: "Tidy the default config file",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return runE(cmd.Context())
 		},

--- a/pkg/kwokctl/cmd/config/tidy/tidy.go
+++ b/pkg/kwokctl/cmd/config/tidy/tidy.go
@@ -33,7 +33,7 @@ func NewCommand(ctx context.Context) *cobra.Command {
 	cmd := &cobra.Command{
 		Args:  cobra.NoArgs,
 		Use:   "tidy",
-		Short: "Tidy the default config file",
+		Short: "Tidy the default config file. When combined with --config, it merges the specified configuration files into the default one.",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return runE(cmd.Context())
 		},

--- a/pkg/kwokctl/cmd/config/view/view.go
+++ b/pkg/kwokctl/cmd/config/view/view.go
@@ -34,7 +34,7 @@ func NewCommand(ctx context.Context) *cobra.Command {
 	cmd := &cobra.Command{
 		Args:  cobra.NoArgs,
 		Use:   "view",
-		Short: "Display the default config file",
+		Short: "Display the default config file. When combined with --config, it displays the default config file with the specified ones merged.",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return runE(cmd.Context())
 		},

--- a/pkg/kwokctl/cmd/config/view/view.go
+++ b/pkg/kwokctl/cmd/config/view/view.go
@@ -34,7 +34,7 @@ func NewCommand(ctx context.Context) *cobra.Command {
 	cmd := &cobra.Command{
 		Args:  cobra.NoArgs,
 		Use:   "view",
-		Short: "Display the default config file with --config",
+		Short: "Display the default config file",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return runE(cmd.Context())
 		},

--- a/site/content/en/docs/generated/kwokctl_config.md
+++ b/site/content/en/docs/generated/kwokctl_config.md
@@ -25,6 +25,6 @@ kwokctl config [command] [flags]
 
 * [kwokctl](kwokctl.md)	 - kwokctl is a tool to streamline the creation and management of clusters, with nodes simulated by kwok
 * [kwokctl config reset](kwokctl_config_reset.md)	 - Remove the default config file
-* [kwokctl config tidy](kwokctl_config_tidy.md)	 - Tidy the default config file with --config
-* [kwokctl config view](kwokctl_config_view.md)	 - Display the default config file with --config
+* [kwokctl config tidy](kwokctl_config_tidy.md)	 - Tidy the default config file. When combined with --config, it merges the specified configuration files into the default one.
+* [kwokctl config view](kwokctl_config_view.md)	 - Display the default config file. When combined with --config, it displays the default config file with the specified ones merged.
 

--- a/site/content/en/docs/generated/kwokctl_config_tidy.md
+++ b/site/content/en/docs/generated/kwokctl_config_tidy.md
@@ -1,6 +1,6 @@
 ## kwokctl config tidy
 
-Tidy the default config file with --config
+Tidy the default config file. When combined with --config, it merges the specified configuration files into the default one.
 
 ```
 kwokctl config tidy [flags]

--- a/site/content/en/docs/generated/kwokctl_config_view.md
+++ b/site/content/en/docs/generated/kwokctl_config_view.md
@@ -1,6 +1,6 @@
 ## kwokctl config view
 
-Display the default config file with --config
+Display the default config file. When combined with --config, it displays the default config file with the specified ones merged.
 
 ```
 kwokctl config view [flags]


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind documentation
/kind cleanup

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

the description of the `config view` and `config tidy` subcommands may lead to misunderstanding. 
Specifically,  the description of the 2 commands says "Display/Tidy the default config file **with –config**", from which somebody might think  "`--config`" is required to show/tidy the default configuration. However, "`--config`" is used to set the config file path in `kwok`. 


#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
