### PR TITLE
Add a pod stage for failing an initContainer 

### DIFF
--- a/kustomize/stage/pod/chaos/pod-init-container-running-failed.yaml
+++ b/kustomize/stage/pod/chaos/pod-init-container-running-failed.yaml
@@ -19,7 +19,7 @@ spec:
       values:
       - 'Pending'
   delay:
-    durationMilliseconds: 1000 
+    durationMilliseconds: 1000
     durationFrom:
       expressionFrom: '.metadata.annotations["pod-init-container-running-failed.stage.kwok.x-k8s.io/delay"]'
     jitterDurationMilliseconds: 1000
@@ -36,7 +36,6 @@ spec:
       {{ $failureReason := or ( index .metadata.annotations "pod-init-container-running-failed.stage.kwok.x-k8s.io/reason" ) $defaultReason }}
       {{ $failureMessage := or ( index .metadata.annotations "pod-init-container-running-failed.stage.kwok.x-k8s.io/message" ) $defaultMessage }}
       {{ $failureExitCode := or ( index .metadata.annotations "pod-init-container-running-failed.stage.kwok.x-k8s.io/exit-code" ) $defaultExitCode }}
-      
       conditions:
       - lastProbeTime: null
         lastTransitionTime: {{ $now | Quote }}
@@ -51,7 +50,6 @@ spec:
         status: "False"
         reason: ""
         type: ContainersReady
-      
       initContainerStatuses:
       {{ range $index, $item := .spec.initContainers }}
       {{ if or ( not $initContainerName ) ( eq $item.name $initContainerName ) }}
@@ -80,7 +78,6 @@ spec:
             startedAt: {{ $now | Quote }}
       {{ end }}
       {{ end }}
-      
       containerStatuses:
       {{ range $index, $item := .spec.containers }}
       - image: {{ $item.image | Quote }}
@@ -92,7 +89,6 @@ spec:
           waiting:
             reason: PodInitializing
       {{ end }}
-      
       hostIP: {{ NodeIPWith .spec.nodeName | Quote }}
       podIP: {{ PodIPWith .spec.nodeName ( or .spec.hostNetwork false ) ( or .metadata.uid "" ) ( or .metadata.name "" ) ( or .metadata.namespace "" ) | Quote }}
       phase: Failed

--- a/kustomize/stage/pod/chaos/pod-init-container-running-failed.yaml
+++ b/kustomize/stage/pod/chaos/pod-init-container-running-failed.yaml
@@ -1,0 +1,99 @@
+apiVersion: kwok.x-k8s.io/v1alpha1
+kind: Stage
+metadata:
+  name: pod-init-container-running-failed
+spec:
+  resourceRef:
+    apiGroup: v1
+    kind: Pod
+  selector:
+    matchExpressions:
+    - key: '.metadata.labels["pod-init-container-running-failed.stage.kwok.x-k8s.io"]'
+      operator: 'In'
+      values:
+      - 'true'
+    - key: '.metadata.deletionTimestamp'
+      operator: 'DoesNotExist'
+    - key: '.status.phase'
+      operator: 'In'
+      values:
+      - 'Pending'
+  delay:
+    durationMilliseconds: 1000 
+    durationFrom:
+      expressionFrom: '.metadata.annotations["pod-init-container-running-failed.stage.kwok.x-k8s.io/delay"]'
+    jitterDurationMilliseconds: 1000
+    jitterDurationFrom:
+      expressionFrom: '.metadata.annotations["pod-init-container-running-failed.stage.kwok.x-k8s.io/jitter-delay"]'
+  weight: 10000
+  next:
+    statusTemplate: |
+      {{ $now := Now }}
+      {{ $defaultReason := "initContainerError" }}
+      {{ $defaultMessage := "initContainer reported errors" }}
+      {{ $defaultExitCode := 1 }}
+      {{ $initContainerName := or ( index .metadata.annotations "pod-init-container-running-failed.stage.kwok.x-k8s.io/container-name" ) "" }}
+      {{ $failureReason := or ( index .metadata.annotations "pod-init-container-running-failed.stage.kwok.x-k8s.io/reason" ) $defaultReason }}
+      {{ $failureMessage := or ( index .metadata.annotations "pod-init-container-running-failed.stage.kwok.x-k8s.io/message" ) $defaultMessage }}
+      {{ $failureExitCode := or ( index .metadata.annotations "pod-init-container-running-failed.stage.kwok.x-k8s.io/exit-code" ) $defaultExitCode }}
+      
+      conditions:
+      - lastProbeTime: null
+        lastTransitionTime: {{ $now | Quote }}
+        status: "False"
+        reason: ""
+        type: Initialized
+      - lastTransitionTime: {{ $now | Quote }}
+        status: "False"
+        reason: ""
+        type: Ready
+      - lastTransitionTime: {{ $now | Quote }}
+        status: "False"
+        reason: ""
+        type: ContainersReady
+      
+      initContainerStatuses:
+      {{ range $index, $item := .spec.initContainers }}
+      {{ if or ( not $initContainerName ) ( eq $item.name $initContainerName ) }}
+      - image: {{ $item.image | Quote }}
+        name: {{ $item.name | Quote }}
+        ready: false
+        restartCount: 0
+        started: false
+        state:
+          terminated:
+            exitCode: {{ $failureExitCode }}
+            finishedAt: {{ $now | Quote }}
+            reason: {{ $failureReason }}
+            message: {{ $failureMessage }}
+            startedAt: {{ $now | Quote }}
+      {{ else }}
+      - image: {{ $item.image | Quote }}
+        name: {{ $item.name | Quote }}
+        ready: true
+        restartCount: 0
+        state:
+          terminated:
+            exitCode: 0
+            finishedAt: {{ $now | Quote }}
+            reason: Completed
+            startedAt: {{ $now | Quote }}
+      {{ end }}
+      {{ end }}
+      
+      containerStatuses:
+      {{ range $index, $item := .spec.containers }}
+      - image: {{ $item.image | Quote }}
+        name: {{ $item.name | Quote }}
+        ready: false
+        restartCount: 0
+        started: false
+        state:
+          waiting:
+            reason: PodInitializing
+      {{ end }}
+      
+      hostIP: {{ NodeIPWith .spec.nodeName | Quote }}
+      podIP: {{ PodIPWith .spec.nodeName ( or .spec.hostNetwork false ) ( or .metadata.uid "" ) ( or .metadata.name "" ) ( or .metadata.namespace "" ) | Quote }}
+      phase: Failed
+      startTime: {{ $now | Quote }}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind feature
#### What this PR does / why we need it:

This PR adds a pod stage that injects an error to initContainer specified by a label and annotations, including the initContainer's name and optional failure message, reason, exit code and delay parameters.

```
labels:
   pod-init-container-running-failed.stage.kwok.x-k8s.io: 'true'
annotations:
   pod-init-container-running-failed.stage.kwok.x-k8s.io/container-name: <failed initContainer name>
   // optional
   pod-init-container-running-failed.stage.kwok.x-k8s.io/reason: <failure reason, the default is "initContainerError">
   pod-init-container-running-failed.stage.kwok.x-k8s.io/message: <failure message, the default is "initContainer reported errors" > 
   pod-init-container-running-failed.stage.kwok.x-k8s.io/exit-code: <exit code, the default is 1>
   pod-init-container-running-failed.stage.kwok.x-k8s.io/delay: <delay in milliseconds> 
   pod-init-container-running-failed.stage.kwok.x-k8s.io/jitter-delay: <jitter delay in milliseconds> 
```

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #
None
#### Special notes for your reviewer:

Questions:

1. How to set the default values for durationFrom and jitterDurationFrom
2. Do we need to set the statues of the other initContainers after the failed initContainer?

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Support the failure of an initContainer in a pod.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
