### PR TITLE
Clarify CRD and CR Acronyms

### DIFF
--- a/site/content/en/docs/user/kwok-in-cluster.md
+++ b/site/content/en/docs/user/kwok-in-cluster.md
@@ -19,13 +19,13 @@ KWOK_REPO=kubernetes-sigs/kwok
 KWOK_LATEST_RELEASE=$(curl "https://api.github.com/repos/${KWOK_REPO}/releases/latest" | jq -r '.tag_name')
 ```
 
-## Deployment kwok and set up CRDs
+## Deploy kwok and set up custom resource definitions (CRDs)
 
 ``` bash
 kubectl apply -f "https://github.com/${KWOK_REPO}/releases/download/${KWOK_LATEST_RELEASE}/kwok.yaml"
 ```
 
-## Set up default CRs of Stages (required)
+## Set up default custom resources (CRs) of stages (required)
 
 {{< hint "warning" >}}
 NOTE: This configures the pod/node emulation behavior, if not it will do nothing.
@@ -35,7 +35,7 @@ NOTE: This configures the pod/node emulation behavior, if not it will do nothing
 kubectl apply -f "https://github.com/${KWOK_REPO}/releases/download/${KWOK_LATEST_RELEASE}/stage-fast.yaml"
 ```
 
-## Set up default CRs of resource usage (optional)
+## Set up default custom resources (CRs) of resource usage (optional)
 
 This allows to simulate the resource usage of nodes, pods and containers.
 


### PR DESCRIPTION
#### What type of PR is this?
/kind documentation

#### What this PR does / why we need it:
It clarifies the meaning of these acronyms, CRD and CR.

Users who are just getting familiarized with kubernetes probably won't get what these mean at first glance. Chances are they are just starting in their certification journey and want to see how easy it is to spin up a cluster, hence stumbling upon KWOK.

Also the title `Deployment kwok` seems misleading. It assumes that the manifest file is a deployment object only, however, it contains several custom resource definitions and a single deployment object. `Deploy kwok and set up custom resource definitions (CRDs)`, properly suits the implementation.

#### Does this PR introduce a user-facing change?
```release-note
NONE
```