### PR TITLE
Correct warning message grammar in the error handling block.

### DIFF
--- a/pkg/kwokctl/cmd/delete/cluster/cluster.go
+++ b/pkg/kwokctl/cmd/delete/cluster/cluster.go
@@ -72,7 +72,7 @@ func runE(ctx context.Context, flags *flagpole) error {
 	rt, err := runtime.DefaultRegistry.Load(ctx, name, workdir)
 	if err != nil {
 		if errors.Is(err, os.ErrNotExist) {
-			logger.Warn("Cluster is not exists")
+			logger.Warn("Cluster does not exist")
 		}
 		return err
 	}

--- a/pkg/kwokctl/cmd/export/logs/logs.go
+++ b/pkg/kwokctl/cmd/export/logs/logs.go
@@ -59,7 +59,7 @@ func runE(ctx context.Context, flags *flagpole, args []string) error {
 	rt, err := runtime.DefaultRegistry.Load(ctx, name, workdir)
 	if err != nil {
 		if errors.Is(err, os.ErrNotExist) {
-			logger.Warn("Cluster is not exists")
+			logger.Warn("Cluster does not exist")
 		}
 		return err
 	}

--- a/pkg/kwokctl/cmd/get/components/components.go
+++ b/pkg/kwokctl/cmd/get/components/components.go
@@ -64,7 +64,7 @@ func runE(ctx context.Context, flags *flagpole) error {
 	rt, err := runtime.DefaultRegistry.Load(ctx, name, workdir)
 	if err != nil {
 		if errors.Is(err, os.ErrNotExist) {
-			logger.Warn("Cluster is not exists")
+			logger.Warn("Cluster does not exist")
 		}
 		return err
 	}

--- a/pkg/kwokctl/cmd/get/kubeconfig/kubeconfig.go
+++ b/pkg/kwokctl/cmd/get/kubeconfig/kubeconfig.go
@@ -84,7 +84,7 @@ func runE(ctx context.Context, flags *flagpole) error {
 	rt, err := runtime.DefaultRegistry.Load(ctx, name, workdir)
 	if err != nil {
 		if errors.Is(err, os.ErrNotExist) {
-			logger.Warn("Cluster is not exists")
+			logger.Warn("Cluster does not exist")
 		}
 		return err
 	}

--- a/pkg/kwokctl/cmd/kubectl/kubectl.go
+++ b/pkg/kwokctl/cmd/kubectl/kubectl.go
@@ -67,7 +67,7 @@ func runE(ctx context.Context, flags *flagpole, args []string) error {
 	rt, err := runtime.DefaultRegistry.Load(ctx, name, workdir)
 	if err != nil {
 		if errors.Is(err, os.ErrNotExist) {
-			logger.Warn("Cluster is not exists")
+			logger.Warn("Cluster does not exist")
 		}
 		return err
 	}

--- a/pkg/kwokctl/cmd/logs/logs.go
+++ b/pkg/kwokctl/cmd/logs/logs.go
@@ -65,7 +65,7 @@ func runE(ctx context.Context, flags *flagpole, args []string) error {
 	rt, err := runtime.DefaultRegistry.Load(ctx, name, workdir)
 	if err != nil {
 		if errors.Is(err, os.ErrNotExist) {
-			logger.Warn("Cluster is not exists")
+			logger.Warn("Cluster does not exist")
 		}
 		return err
 	}

--- a/pkg/kwokctl/cmd/scale/scale.go
+++ b/pkg/kwokctl/cmd/scale/scale.go
@@ -77,7 +77,7 @@ func runE(ctx context.Context, flags *flagpole, args []string) error {
 	rt, err := runtime.DefaultRegistry.Load(ctx, name, workdir)
 	if err != nil {
 		if errors.Is(err, os.ErrNotExist) {
-			logger.Warn("Cluster is not exists")
+			logger.Warn("Cluster does not exist")
 		}
 		return err
 	}

--- a/pkg/kwokctl/cmd/snapshot/record/record.go
+++ b/pkg/kwokctl/cmd/snapshot/record/record.go
@@ -79,7 +79,7 @@ func runE(ctx context.Context, flags *flagpole) error {
 	rt, err := runtime.DefaultRegistry.Load(ctx, name, workdir)
 	if err != nil {
 		if errors.Is(err, os.ErrNotExist) {
-			logger.Warn("Cluster is not exists")
+			logger.Warn("Cluster does not exist")
 		}
 		return err
 	}

--- a/pkg/kwokctl/cmd/snapshot/replay/replay.go
+++ b/pkg/kwokctl/cmd/snapshot/replay/replay.go
@@ -82,7 +82,7 @@ func runE(ctx context.Context, flags *flagpole) error {
 	rt, err := runtime.DefaultRegistry.Load(ctx, name, workdir)
 	if err != nil {
 		if errors.Is(err, os.ErrNotExist) {
-			logger.Warn("Cluster is not exists")
+			logger.Warn("Cluster does not exist")
 		}
 		return err
 	}

--- a/pkg/kwokctl/cmd/snapshot/restore/restore.go
+++ b/pkg/kwokctl/cmd/snapshot/restore/restore.go
@@ -76,7 +76,7 @@ func runE(ctx context.Context, flags *flagpole) error {
 	rt, err := runtime.DefaultRegistry.Load(ctx, name, workdir)
 	if err != nil {
 		if errors.Is(err, os.ErrNotExist) {
-			logger.Warn("Cluster is not exists")
+			logger.Warn("Cluster does not exist")
 		}
 		return err
 	}

--- a/pkg/kwokctl/cmd/snapshot/save/save.go
+++ b/pkg/kwokctl/cmd/snapshot/save/save.go
@@ -76,7 +76,7 @@ func runE(ctx context.Context, flags *flagpole) error {
 	rt, err := runtime.DefaultRegistry.Load(ctx, name, workdir)
 	if err != nil {
 		if errors.Is(err, os.ErrNotExist) {
-			logger.Warn("Cluster is not exists")
+			logger.Warn("Cluster does not exist")
 		}
 		return err
 	}

--- a/pkg/kwokctl/cmd/start/cluster/cluster.go
+++ b/pkg/kwokctl/cmd/start/cluster/cluster.go
@@ -74,7 +74,7 @@ func runE(ctx context.Context, flags *flagpole) error {
 	rt, err := runtime.DefaultRegistry.Load(ctx, name, workdir)
 	if err != nil {
 		if errors.Is(err, os.ErrNotExist) {
-			logger.Warn("Cluster is not exists")
+			logger.Warn("Cluster does not exist")
 		}
 		return err
 	}

--- a/pkg/kwokctl/cmd/stop/cluster/cluster.go
+++ b/pkg/kwokctl/cmd/stop/cluster/cluster.go
@@ -62,7 +62,7 @@ func runE(ctx context.Context, flags *flagpole) error {
 	rt, err := runtime.DefaultRegistry.Load(ctx, name, workdir)
 	if err != nil {
 		if errors.Is(err, os.ErrNotExist) {
-			logger.Warn("Cluster is not exists")
+			logger.Warn("Cluster does not exist")
 		}
 		return err
 	}


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:
While working with kwok, I realized that if I input the wrong cluster name when doing maybe `kwokctl get clusters --name <cluster-name>` a warning message pops up saying "Cluster is not exists". This grammatically doesn't seem right. I updated it to "Cluster does not exist".

#### Does this PR introduce a user-facing change?

```release-note
The initial warning output "Cluster is not exists" has been removed and updated to "Cluster does not exist".
```