### PR TITLE
Fix replicas data type specified in kwokctl_scale.md

### DIFF
--- a/site/content/en/docs/generated/kwokctl_scale.md
+++ b/site/content/en/docs/generated/kwokctl_scale.md
@@ -12,7 +12,7 @@ kwokctl scale [node, pod, ...] [name] [flags]
   -h, --help                help for scale
   -n, --namespace string    Namespace of resource to scale
       --param stringArray   Parameter to update
-      --replicas uint       Number of replicas (default 1)
+      --replicas int        Number of replicas (default 1)
       --serial-length int   Length of serial number (default 6)
 ```
 


### PR DESCRIPTION
#### What type of PR is this?

/kind documentation

#### What this PR does / why we need it:

It corrects the data type specified for the `--replicas` flag. I changed it from `uint` to `int`.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```