### PR TITLE
Update Prometheus Data Source Docs for Grafana

### DIFF
--- a/site/content/en/docs/examples/prometheus.md
+++ b/site/content/en/docs/examples/prometheus.md
@@ -25,9 +25,9 @@ docker run -d --name=grafana -p 3000:3000 docker.io/grafana/grafana:9.4.7
 ```
 
 1. Open your web browser and go to [http://localhost:3000]
-2. On the login page, enter `admin` for username and password
-3. Add the Prometheus data source, `http://host.docker.internal:9090`, on Grafana
-4. Import via [grafana.com code] `16248` on Grafana
+2. On the login page, enter `admin` for username and password.
+3. Add the Prometheus data source, `http://host.docker.internal:9090`, on Grafana, replacing `hostIP` with the IP address of your host.
+4. Import via [grafana.com code] `16248` on Grafana.
 
 Now you can see the Grafana dashboard for the cluster.
 


### PR DESCRIPTION
#### What type of PR is this?
/kind documentation

#### What this PR does / why we need it:
On [this](https://kwok.sigs.k8s.io/docs/examples/prometheus/) existing documentation, the below sentence exists.

> Add the Prometheus data source, `http://host.docker.internal:9090`, on Grafana

While setting up Prometheus, using the above URL to access the host port didn't work on my Ubuntu machine running on AWS, I had this error `Error reading Prometheus: Post "http://host.docker.internal:9090/api/v1/query": dial tcp: lookup host.docker.internal on 172.31.0.2:53: no such host`.

According to this [Stackoverflow](https://stackoverflow.com/questions/48546124/what-is-the-linux-equivalent-of-host-docker-internal) answer, the URL doesn't work by default, you'd have to use this flag `--add-host=host.docker.internal:host-gateway` when creating the container.

I opted to use my host's IP address. In my case, this was the public IP address of my host.

My suggestion is to specify that users either use `http://host.docker.internal:9090` or `http://hostIP:9090`

The documentation then becomes the below:
> Add the Prometheus data source, `http://host.docker.internal:9090` or `http://hostIP:9090`, on Grafana, replacing `hostIP` with the IP address of your host.

I also added full stops where necessary on other ordered lists.

#### Which issue(s) this PR fixes:

Fixes #1078

#### Does this PR introduce a user-facing change?
```release-note
NONE
```