### PR TITLE
Correct grammar in sentences containing 'information how to'.

### DIFF
--- a/pkg/apis/internalversion/attach_types.go
+++ b/pkg/apis/internalversion/attach_types.go
@@ -35,7 +35,7 @@ type AttachSpec struct {
 	Attaches []AttachConfig
 }
 
-// AttachConfig holds information how to attach.
+// AttachConfig holds information on how to attach.
 type AttachConfig struct {
 	// Containers is list of container names.
 	Containers []string

--- a/pkg/apis/internalversion/exec_types.go
+++ b/pkg/apis/internalversion/exec_types.go
@@ -35,16 +35,16 @@ type ExecSpec struct {
 	Execs []ExecTarget
 }
 
-// ExecTarget holds information how to exec.
+// ExecTarget holds information on how to exec.
 type ExecTarget struct {
 	// Containers is a list of containers to exec.
 	// if not set, all containers will be execed.
 	Containers []string
-	// Local holds information how to exec to a local target.
+	// Local holds information on how to exec to a local target.
 	Local *ExecTargetLocal
 }
 
-// ExecTargetLocal holds information how to exec to a local target.
+// ExecTargetLocal holds information on how to exec to a local target.
 type ExecTargetLocal struct {
 	// WorkDir is the working directory to exec with.
 	WorkDir string

--- a/pkg/apis/internalversion/logs_types.go
+++ b/pkg/apis/internalversion/logs_types.go
@@ -35,7 +35,7 @@ type LogsSpec struct {
 	Logs []Log
 }
 
-// Log holds information how to forward logs.
+// Log holds information on how to forward logs.
 type Log struct {
 	// Containers is list of container names.
 	Containers []string

--- a/pkg/apis/internalversion/object_selector.go
+++ b/pkg/apis/internalversion/object_selector.go
@@ -20,7 +20,7 @@ import (
 	"sigs.k8s.io/kwok/pkg/utils/slices"
 )
 
-// ObjectSelector holds information how to match based on namespace and name.
+// ObjectSelector holds information on how to match based on namespace and name.
 type ObjectSelector struct {
 	// MatchNamespaces is a list of namespaces to match.
 	// if not set, all namespaces will be matched.

--- a/pkg/apis/internalversion/port_forward_types.go
+++ b/pkg/apis/internalversion/port_forward_types.go
@@ -35,7 +35,7 @@ type PortForwardSpec struct {
 	Forwards []Forward
 }
 
-// Forward holds information how to forward based on ports.
+// Forward holds information on how to forward based on ports.
 type Forward struct {
 	// Ports is a list of ports to forward.
 	// if not set, all ports will be forwarded.
@@ -47,7 +47,7 @@ type Forward struct {
 	Command []string
 }
 
-// ForwardTarget holds information how to forward to a target.
+// ForwardTarget holds information on how to forward to a target.
 type ForwardTarget struct {
 	// Port is the port to forward to.
 	Port int32

--- a/pkg/apis/v1alpha1/attach_types.go
+++ b/pkg/apis/v1alpha1/attach_types.go
@@ -61,7 +61,7 @@ type AttachSpec struct {
 	Attaches []AttachConfig `json:"attaches"`
 }
 
-// AttachConfig holds information how to attach.
+// AttachConfig holds information on how to attach.
 type AttachConfig struct {
 	// Containers is list of container names.
 	Containers []string `json:"containers,omitempty"`

--- a/pkg/apis/v1alpha1/exec_types.go
+++ b/pkg/apis/v1alpha1/exec_types.go
@@ -61,16 +61,16 @@ type ExecSpec struct {
 	Execs []ExecTarget `json:"execs"`
 }
 
-// ExecTarget holds information how to exec.
+// ExecTarget holds information on how to exec.
 type ExecTarget struct {
 	// Containers is a list of containers to exec.
 	// if not set, all containers will be execed.
 	Containers []string `json:"containers,omitempty"`
-	// Local holds information how to exec to a local target.
+	// Local holds information on how to exec to a local target.
 	Local *ExecTargetLocal `json:"local,omitempty"`
 }
 
-// ExecTargetLocal holds information how to exec to a local target.
+// ExecTargetLocal holds information on how to exec to a local target.
 type ExecTargetLocal struct {
 	// WorkDir is the working directory to exec with.
 	WorkDir string `json:"workDir,omitempty"`

--- a/pkg/apis/v1alpha1/logs_types.go
+++ b/pkg/apis/v1alpha1/logs_types.go
@@ -61,7 +61,7 @@ type LogsSpec struct {
 	Logs []Log `json:"logs"`
 }
 
-// Log holds information how to forward logs.
+// Log holds information on how to forward logs.
 type Log struct {
 	// Containers is list of container names.
 	Containers []string `json:"containers,omitempty"`

--- a/pkg/apis/v1alpha1/object_selector.go
+++ b/pkg/apis/v1alpha1/object_selector.go
@@ -16,7 +16,7 @@ limitations under the License.
 
 package v1alpha1
 
-// ObjectSelector holds information how to match based on namespace and name.
+// ObjectSelector holds information on how to match based on namespace and name.
 type ObjectSelector struct {
 	// MatchNamespaces is a list of namespaces to match.
 	// if not set, all namespaces will be matched.

--- a/pkg/apis/v1alpha1/port_forward_types.go
+++ b/pkg/apis/v1alpha1/port_forward_types.go
@@ -61,7 +61,7 @@ type PortForwardSpec struct {
 	Forwards []Forward `json:"forwards"`
 }
 
-// Forward holds information how to forward based on ports.
+// Forward holds information on how to forward based on ports.
 type Forward struct {
 	// Ports is a list of ports to forward.
 	// if not set, all ports will be forwarded.
@@ -73,7 +73,7 @@ type Forward struct {
 	Command []string `json:"command,omitempty"`
 }
 
-// ForwardTarget holds information how to forward to a target.
+// ForwardTarget holds information on how to forward to a target.
 type ForwardTarget struct {
 	// Port is the port to forward to.
 	// +kubebuilder:validation:Required

--- a/site/content/en/docs/generated/apis.md
+++ b/site/content/en/docs/generated/apis.md
@@ -3911,7 +3911,7 @@ AttachConfig
 <a href="#kwok.x-k8s.io/v1alpha1.ClusterAttachSpec">ClusterAttachSpec</a>
 </p>
 <p>
-<p>AttachConfig holds information how to attach.</p>
+<p>AttachConfig holds information on how to attach.</p>
 </p>
 <table>
 <thead>
@@ -4725,7 +4725,7 @@ ExecTarget
 <a href="#kwok.x-k8s.io/v1alpha1.ExecSpec">ExecSpec</a>
 </p>
 <p>
-<p>ExecTarget holds information how to exec.</p>
+<p>ExecTarget holds information on how to exec.</p>
 </p>
 <table>
 <thead>
@@ -4757,7 +4757,7 @@ ExecTargetLocal
 </em>
 </td>
 <td>
-<p>Local holds information how to exec to a local target.</p>
+<p>Local holds information on how to exec to a local target.</p>
 </td>
 </tr>
 </tbody>
@@ -4771,7 +4771,7 @@ ExecTargetLocal
 <a href="#kwok.x-k8s.io/v1alpha1.ExecTarget">ExecTarget</a>
 </p>
 <p>
-<p>ExecTargetLocal holds information how to exec to a local target.</p>
+<p>ExecTargetLocal holds information on how to exec to a local target.</p>
 </p>
 <table>
 <thead>
@@ -4895,7 +4895,7 @@ Forward
 <a href="#kwok.x-k8s.io/v1alpha1.PortForwardSpec">PortForwardSpec</a>
 </p>
 <p>
-<p>Forward holds information how to forward based on ports.</p>
+<p>Forward holds information on how to forward based on ports.</p>
 </p>
 <table>
 <thead>
@@ -4953,7 +4953,7 @@ ForwardTarget
 <a href="#kwok.x-k8s.io/v1alpha1.Forward">Forward</a>
 </p>
 <p>
-<p>ForwardTarget holds information how to forward to a target.</p>
+<p>ForwardTarget holds information on how to forward to a target.</p>
 </p>
 <table>
 <thead>
@@ -5069,7 +5069,7 @@ Log
 <a href="#kwok.x-k8s.io/v1alpha1.LogsSpec">LogsSpec</a>
 </p>
 <p>
-<p>Log holds information how to forward logs.</p>
+<p>Log holds information on how to forward logs.</p>
 </p>
 <table>
 <thead>
@@ -5482,7 +5482,7 @@ ObjectSelector
 <a href="#kwok.x-k8s.io/v1alpha1.ClusterResourceUsageSpec">ClusterResourceUsageSpec</a>
 </p>
 <p>
-<p>ObjectSelector holds information how to match based on namespace and name.</p>
+<p>ObjectSelector holds information on how on to match based on namespace and name.</p>
 </p>
 <table>
 <thead>

--- a/site/content/en/docs/generated/apis.md
+++ b/site/content/en/docs/generated/apis.md
@@ -5482,7 +5482,7 @@ ObjectSelector
 <a href="#kwok.x-k8s.io/v1alpha1.ClusterResourceUsageSpec">ClusterResourceUsageSpec</a>
 </p>
 <p>
-<p>ObjectSelector holds information on how on to match based on namespace and name.</p>
+<p>ObjectSelector holds information on how to match based on namespace and name.</p>
 </p>
 <table>
 <thead>


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup
/kind documentation

#### What this PR does / why we need it:
While learning to use the `exec` feature, I realized some sentences have preposition issues. Prepositions use words like at, in, on, etc. to describe where things are, or how something is used. The sentences didn't describe how the noun "information" is used on a local target. 

I added "on" before "how" to correct this.

This excludes files in the `kustomize/crd/bases/` file path.

#### Does this PR introduce a user-facing change?

```release-note
Sentences containing "information how to" have been removed and updated to "information on how to".
```