### PR TITLE
adding dryrun_test.go

### DIFF
--- a/pkg/kwokctl/dryrun/dryrun_test.go
+++ b/pkg/kwokctl/dryrun/dryrun_test.go
@@ -1,0 +1,97 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package dryrun
+
+import (
+	"bytes"
+	"testing"
+)
+
+// TestIsCatToFileWriter tests the IsCatToFileWriter function
+func TestIsCatToFileWriter(t *testing.T) {
+	writer := newCatToFileWriter(&bytes.Buffer{}, "testfile")
+
+	name, ok := IsCatToFileWriter(writer)
+	if !ok || name != "testfile" {
+		t.Errorf("expected true and 'testfile', got %v and %q", ok, name)
+	}
+
+	_, ok = IsCatToFileWriter(&bytes.Buffer{})
+	if ok {
+		t.Errorf("expected false, got %v", ok)
+	}
+}
+
+// TestDryRunWriterWriteAndClose tests the Write and Close methods of dryRunWriter
+func TestDryRunWriterWriteAndClose(t *testing.T) {
+	var buf bytes.Buffer
+	writer := newCatToFileWriter(&buf, "testfile")
+
+	data := []byte("test data")
+	n, err := writer.Write(data)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if n != len(data) {
+		t.Errorf("expected %d bytes written, got %d", len(data), n)
+	}
+
+	err = writer.Close()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	expected := "echo test data >testfile\n"
+	actual := buf.String()
+	if actual != expected {
+		t.Errorf("expected %q, got %q", expected, actual)
+	}
+}
+
+// TestDryRunWriterCloseWithNewline tests the Close method of dryRunWriter with newline in data
+func TestDryRunWriterCloseWithNewline(t *testing.T) {
+	var buf bytes.Buffer
+	writer := newCatToFileWriter(&buf, "testfile")
+
+	data := []byte("line1\nline2")
+	_, _ = writer.Write(data)
+
+	err := writer.Close()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	expected := "cat <<EOF >testfile\nline1\nline2\nEOF\n"
+	actual := buf.String()
+	if actual != expected {
+		t.Errorf("expected %q, got %q", expected, actual)
+	}
+}
+
+// TestNewCatToFileWriter tests the NewCatToFileWriter function
+func TestNewCatToFileWriter(t *testing.T) {
+	writer := NewCatToFileWriter("testfile")
+	defer func() {
+		if err := writer.Close(); err != nil {
+			t.Fatalf("Failed to close : %v", err)
+		}
+	}()
+
+	if _, ok := writer.(*dryRunWriter); !ok {
+		t.Errorf("expected *dryRunWriter, got %T", writer)
+	}
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
kind feature

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
adding dryrun_test.go
#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
nono
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
nono
```
