### PR TITLE
[WIP] Support for exposing component ports to hosts

### DIFF
--- a/pkg/kwokctl/cmd/portforward/portforward.go
+++ b/pkg/kwokctl/cmd/portforward/portforward.go
@@ -1,0 +1,124 @@
+package portforward
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	"sigs.k8s.io/kwok/pkg/apis/internalversion"
+	"sigs.k8s.io/kwok/pkg/config"
+	"sigs.k8s.io/kwok/pkg/consts"
+	"sigs.k8s.io/kwok/pkg/kwokctl/runtime"
+	"sigs.k8s.io/kwok/pkg/log"
+	"sigs.k8s.io/kwok/pkg/utils/exec"
+	"sigs.k8s.io/kwok/pkg/utils/path"
+)
+
+type flagpole struct {
+	Name      string
+	LocalPort string
+	*internalversion.KwokctlConfiguration
+
+}
+
+// NewCommand returns a new cobra.Command for port-forward in a cluster
+func NewCommand(ctx context.Context) *cobra.Command {
+	flags := &flagpole{}
+
+	cmd := &cobra.Command{
+		Use:   "port-forward NAME LOCAL_PORT",
+		Short: "Forward a local port to a port on a pod",
+		Args:  cobra.ExactArgs(2),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			flags.Name = config.DefaultCluster
+			flags.LocalPort = args[1]
+			err := runE(cmd.Context(), flags, args)
+			if err != nil {
+				return fmt.Errorf("%v: %w", args, err)
+			}
+			return nil
+		},
+	}
+	cmd.DisableFlagParsing = true
+	return cmd
+}
+
+func runE(ctx context.Context, flags *flagpole, args []string) error {
+	name := config.ClusterName(flags.Name)
+	workdir := path.Join(config.ClustersDir, flags.Name)
+
+	logger := log.FromContext(ctx)
+	logger = logger.With("cluster", flags.Name)
+	ctx = log.NewContext(ctx, logger)
+
+	rt, err := runtime.DefaultRegistry.Load(ctx, name, workdir)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			logger.Warn("Cluster does not exist")
+		}
+		return err
+	}
+    
+	if flags.Options.Runtime == consts.RuntimeTypeKind {
+		return portForwardKind(ctx, name, flags.LocalPort, *logger)
+	} else if flags.Options.Runtime == consts.RuntimeTypeDocker || flags.Options.Runtime == consts.RuntimeTypeKindPodman ||
+	flags.Options.Runtime == consts.RuntimeTypeKindNerdctl {
+		return portForwardContainer(ctx, name, flags.LocalPort, *logger)
+	} else if flags.Options.Runtime == consts.RuntimeTypeBinary {
+        return portForwardBinary(name, flags.LocalPort, *logger)
+	}
+	err = rt.KubectlInCluster(exec.WithStdIO(ctx), args...)
+
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func portForwardBinary(name string, localPort string, logger log.Logger) error {
+	logger.Info("Starting TCP forward for binary runtime", "name", name, "port", localPort)
+	// Add  TCP forward implementation here
+	return nil
+}
+
+func portForwardContainer(ctx context.Context, name string, localPort string, logger log.Logger) error {
+	logger.Info("Starting TCP forward for container runtime", "name", name, "port", localPort)
+	cmd, err := exec.Command(ctx, "docker", "exec", "-i", name, "nc", "localhost", localPort)
+	if err != nil {
+		
+	}
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	return cmd.Run()
+}
+
+func portForwardKind(ctx context.Context, name string, localPort string, logger log.Logger) error {
+	logger.Info("Converting to kubectl port-forward for kind runtime", "name", name, "port", localPort)
+	cmd, err := exec.Command(ctx, "kubectl", "port-forward", name, fmt.Sprintf("%d:%d", localPort, localPort))
+	if err != nil {
+		return err
+	}
+
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+
+	err = cmd.Start()
+	if err != nil {
+		return fmt.Errorf("cmd start: %s %s: %w", "kubectl", strings.Join([]string{"port-forward", name, fmt.Sprintf("%d:%d", localPort, localPort)}, " "), err)
+	}
+
+	err = cmd.Wait()
+	if err != nil {
+		if buf, ok := cmd.Stderr.(*bytes.Buffer); ok {
+			return fmt.Errorf("cmd wait: %s %s: %w\n%s", "kubectl", strings.Join([]string{"port-forward", name, fmt.Sprintf("%d:%d", localPort, localPort)}, " "), err, buf.String())
+		}
+		return fmt.Errorf("cmd wait: %s %s: %w", "kubectl", strings.Join([]string{"port-forward", name, fmt.Sprintf("%d:%d", localPort, localPort)}, " "), err)
+	}
+
+	return nil
+}

--- a/pkg/kwokctl/cmd/root.go
+++ b/pkg/kwokctl/cmd/root.go
@@ -32,6 +32,7 @@ import (
 	"sigs.k8s.io/kwok/pkg/kwokctl/cmd/hack"
 	"sigs.k8s.io/kwok/pkg/kwokctl/cmd/kubectl"
 	"sigs.k8s.io/kwok/pkg/kwokctl/cmd/logs"
+	"sigs.k8s.io/kwok/pkg/kwokctl/cmd/portforward"
 	"sigs.k8s.io/kwok/pkg/kwokctl/cmd/scale"
 	"sigs.k8s.io/kwok/pkg/kwokctl/cmd/snapshot"
 	"sigs.k8s.io/kwok/pkg/kwokctl/cmd/start"
@@ -72,6 +73,7 @@ func NewCommand(ctx context.Context) *cobra.Command {
 		snapshot.NewCommand(ctx),
 		export.NewCommand(ctx),
 		hack.NewCommand(ctx),
+		portforward.NewCommand(ctx),
 	)
 	return cmd
 }

--- a/site/content/en/docs/generated/kwokctl.md
+++ b/site/content/en/docs/generated/kwokctl.md
@@ -27,6 +27,7 @@ kwokctl [command] [flags]
 * [kwokctl hack](kwokctl_hack.md)	 - [experimental] Hack [get, put, delete] resources in etcd without apiserver
 * [kwokctl kubectl](kwokctl_kubectl.md)	 - kubectl in cluster
 * [kwokctl logs](kwokctl_logs.md)	 - Logs one of [audit, etcd, kube-apiserver, kube-controller-manager, kube-scheduler, kwok-controller, dashboard, metrics-server, prometheus, jaeger]
+* [kwokctl port-forward](kwokctl_port-forward.md)	 - Forward a local port to a port on a pod
 * [kwokctl scale](kwokctl_scale.md)	 - Scale a resource in cluster
 * [kwokctl snapshot](kwokctl_snapshot.md)	 - Snapshot [save, restore, record, replay, export] one of cluster
 * [kwokctl start](kwokctl_start.md)	 - Start one of [cluster]

--- a/site/content/en/docs/generated/kwokctl_port-forward.md
+++ b/site/content/en/docs/generated/kwokctl_port-forward.md
@@ -1,0 +1,27 @@
+## kwokctl port-forward
+
+Forward a local port to a port on a pod
+
+```
+kwokctl port-forward NAME LOCAL_PORT [flags]
+```
+
+### Options
+
+```
+  -h, --help   help for port-forward
+```
+
+### Options inherited from parent commands
+
+```
+  -c, --config strings   config path (default [~/.kwok/kwok.yaml])
+      --dry-run          Print the command that would be executed, but do not execute it
+      --name string      cluster name (default "kwok")
+  -v, --v log-level      number for the log level verbosity (DEBUG, INFO, WARN, ERROR) or (-4, 0, 4, 8) (default INFO)
+```
+
+### SEE ALSO
+
+* [kwokctl](kwokctl.md)	 - kwokctl is a tool to streamline the creation and management of clusters, with nodes simulated by kwok
+


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind feature
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

Add port-forwrd support for exposing components ports to hosts in container executing. In this PR I tried to achieve the command as shown below 
```
kwokctl port-forward NAME LOCAL_PORT
```

In most cases, the ports are not actively exposed when the cluster is created, and trying to access a component's port in the middle of the process can be difficult, so we wanted a way to support it.
#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #1036 

#### Special notes for your reviewer:

@wzshiming I tried to add the `port-forward` as the new subcommand to kwokctl , This can be treated as basic PR that has scope of discussion regarding implementation of TCP forward in case of different runtime.

