### PR TITLE
Bump golangci-lint to v1.58.2

### DIFF
--- a/.github/workflows/golangci-lint.yaml
+++ b/.github/workflows/golangci-lint.yaml
@@ -16,5 +16,5 @@ jobs:
     - name: golangci-lint
       uses: golangci/golangci-lint-action@v6
       with:
-        version: v1.55.2
+        version: v1.58.2
         args: --timeout=30m --config=.golangci.yaml

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -59,9 +59,11 @@ linters-settings:
     - pkg: k8s.io/apimachinery/pkg/api/errors
       alias: apierrors
   staticcheck:
-    go: "1.22"
+    run:
+      go: "1.22"
   stylecheck:
-    go: "1.22"
+    run:
+      go: "1.22"
     # STxxxx checks in https://staticcheck.io/docs/configuration/options/#checks
     checks: ["all", "-ST1000", "-ST1003"]
   depguard:
@@ -180,17 +182,20 @@ linters-settings:
       disabled: true
     - name: error-strings
       disabled: true
+    - name: max-control-nesting
+      arguments:
+      - 6
 issues:
   max-same-issues: 0
   max-issues-per-linter: 0
   # We are disabling default golangci exclusions because we want to help reviewers to focus on reviewing the most relevant
   # changes in PRs and avoid nitpicking.
   exclude-use-default: false
+  exclude-files:
+  - ".*\\.zz_generated\\..*"
 run:
   concurrency: 1
   timeout: 10m
   allow-parallel-runners: false
   skip-dirs-use-default: true
-  skip-files:
-  - ".*\\.zz_generated\\..*"
   go: "1.22"

--- a/hack/update-go-lint.sh
+++ b/hack/update-go-lint.sh
@@ -21,6 +21,6 @@ DIR="$(dirname "${BASH_SOURCE[0]}")"
 
 ROOT_DIR="$(realpath "${DIR}/..")"
 
-COMMAND=(go run github.com/golangci/golangci-lint/cmd/golangci-lint@v1.55.2)
+COMMAND=(go run github.com/golangci/golangci-lint/cmd/golangci-lint@v1.58.2)
 
 cd "${ROOT_DIR}" && "${COMMAND[@]}" run -c "${ROOT_DIR}/.golangci.yaml" --fix

--- a/hack/verify-go-lint.sh
+++ b/hack/verify-go-lint.sh
@@ -21,6 +21,6 @@ DIR="$(dirname "${BASH_SOURCE[0]}")"
 
 ROOT_DIR="$(realpath "${DIR}/..")"
 
-COMMAND=(go run github.com/golangci/golangci-lint/cmd/golangci-lint@v1.55.2)
+COMMAND=(go run github.com/golangci/golangci-lint/cmd/golangci-lint@v1.58.2)
 
 cd "${ROOT_DIR}" && "${COMMAND[@]}" run -c "${ROOT_DIR}/.golangci.yaml"


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

This PR updates the `.golangci.yaml` file to address the following warnings:
- Deprecated configuration options `linters.staticcheck.go` and `linters.stylecheck.go` are replaced with global `run.go`.
- Moved exclude files configuration from the deprecated `run.skip-files` to `issues.exclude-files`.

#### Special notes for your reviewer:

None

#### Does this PR introduce a user-facing change?
```release-note
NONE
```
