### PR TITLE
[kwokctl] Added --all flag to kwokctl delete cluster command

### DIFF
--- a/site/content/en/docs/generated/kwokctl_create_cluster.md
+++ b/site/content/en/docs/generated/kwokctl_create_cluster.md
@@ -65,10 +65,10 @@ kwokctl create cluster [flags]
       --kube-scheduler-port uint32              Port of kube-scheduler given to the host, only for binary and docker/podman/nerdctl runtime
       --kubeconfig string                       The path to the kubeconfig file will be added to the newly created cluster and set to current-context (default "~/.kube/config")
       --kwok-controller-binary string           Binary of kwok-controller, only for binary runtime
-                                                 (default "https://github.com/kubernetes-sigs/kwok/releases/download/v0.5.2/kwok-linux-amd64")
+                                                 (default "https://github.com/kubernetes-sigs/kwok/releases/download/v0.6.0/kwok-linux-amd64")
       --kwok-controller-image string            Image of kwok-controller, only for docker/podman/nerdctl/kind/kind-podman runtime
                                                 '${KWOK_IMAGE_PREFIX}/kwok:${KWOK_VERSION}'
-                                                 (default "registry.k8s.io/kwok/kwok:v0.5.2")
+                                                 (default "registry.k8s.io/kwok/kwok:v0.6.0")
       --metrics-server-binary string            Binary of metrics-server, only for binary runtime (default "https://github.com/kubernetes-sigs/metrics-server/releases/download/v0.7.0/metrics-server-linux-amd64")
       --metrics-server-image string             Image of metrics-server, only for docker/podman/nerdctl/kind/kind-podman runtime
                                                 '${KWOK_METRICS_SERVER_IMAGE_PREFIX}/metrics-server:${KWOK_METRICS_SERVER_VERSION}'

--- a/site/content/en/docs/generated/kwokctl_create_cluster.md
+++ b/site/content/en/docs/generated/kwokctl_create_cluster.md
@@ -65,10 +65,10 @@ kwokctl create cluster [flags]
       --kube-scheduler-port uint32              Port of kube-scheduler given to the host, only for binary and docker/podman/nerdctl runtime
       --kubeconfig string                       The path to the kubeconfig file will be added to the newly created cluster and set to current-context (default "~/.kube/config")
       --kwok-controller-binary string           Binary of kwok-controller, only for binary runtime
-                                                 (default "https://github.com/kubernetes-sigs/kwok/releases/download/v0.6.0/kwok-linux-amd64")
+                                                 (default "https://github.com/kubernetes-sigs/kwok/releases/download/v0.5.2/kwok-linux-amd64")
       --kwok-controller-image string            Image of kwok-controller, only for docker/podman/nerdctl/kind/kind-podman runtime
                                                 '${KWOK_IMAGE_PREFIX}/kwok:${KWOK_VERSION}'
-                                                 (default "registry.k8s.io/kwok/kwok:v0.6.0")
+                                                 (default "registry.k8s.io/kwok/kwok:v0.5.2")
       --metrics-server-binary string            Binary of metrics-server, only for binary runtime (default "https://github.com/kubernetes-sigs/metrics-server/releases/download/v0.7.0/metrics-server-linux-amd64")
       --metrics-server-image string             Image of metrics-server, only for docker/podman/nerdctl/kind/kind-podman runtime
                                                 '${KWOK_METRICS_SERVER_IMAGE_PREFIX}/metrics-server:${KWOK_METRICS_SERVER_VERSION}'

--- a/site/content/en/docs/generated/kwokctl_delete_cluster.md
+++ b/site/content/en/docs/generated/kwokctl_delete_cluster.md
@@ -10,7 +10,6 @@ kwokctl delete cluster [flags]
 
 ```
       --all                 Delete all clusters managed by kwokctl
-      --force               Delete cluster depending on runtime availability
   -h, --help                help for cluster
       --kubeconfig string   The path to the kubeconfig file that will remove the deleted cluster (default "~/.kube/config")
 ```

--- a/site/content/en/docs/generated/kwokctl_delete_cluster.md
+++ b/site/content/en/docs/generated/kwokctl_delete_cluster.md
@@ -9,7 +9,8 @@ kwokctl delete cluster [flags]
 ### Options
 
 ```
-      --all                 Delete all clusters
+      --all                 Delete all clusters managed by kwokctl
+      --force               Delete cluster depending on runtime availability
   -h, --help                help for cluster
       --kubeconfig string   The path to the kubeconfig file that will remove the deleted cluster (default "~/.kube/config")
 ```

--- a/site/content/en/docs/generated/kwokctl_delete_cluster.md
+++ b/site/content/en/docs/generated/kwokctl_delete_cluster.md
@@ -9,6 +9,7 @@ kwokctl delete cluster [flags]
 ### Options
 
 ```
+      --all                 Delete all clusters
   -h, --help                help for cluster
       --kubeconfig string   The path to the kubeconfig file that will remove the deleted cluster (default "~/.kube/config")
 ```


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind feature

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
This PR adds `--all` flag to `kwokctl delete cluster` command that currently supports the deletion of specific clusters through `--name` flag.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #1123 , #1124

#### Special notes for your reviewer:


#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
[kwokctl] Added --all flag to kwokctl delete cluster command
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
NONE
```

After making the corresponding changes to the files as you can see in the commits, I tried testing the implementation by re-building the kwokctl binary. But go this:
<img width="1259" alt="Screenshot 2024-05-29 at 3 48 46 PM" src="https://github.com/kubernetes-sigs/kwok/assets/84619980/9a38f7af-578b-4a61-843d-56b9da7adcaa">


