### PR TITLE
[Kwokctl]: Added kube-controller-manager certificate for kind and binary runtime

### DIFF
--- a/pkg/kwokctl/components/kube_controller_manager.go
+++ b/pkg/kwokctl/components/kube_controller_manager.go
@@ -42,7 +42,7 @@ type BuildKubeControllerManagerComponentConfig struct {
 	AdminCertPath                      string
 	AdminKeyPath                       string
 	KubeControllerManagerCertPath      string // Add field for kube-controller-manager specific cert
-	KubeControllerManagerKeyPath       string 
+	KubeControllerManagerKeyPath       string
 	KubeAuthorization                  bool
 	KubeconfigPath                     string
 	KubeFeatureGates                   string
@@ -121,7 +121,7 @@ func BuildKubeControllerManagerComponent(conf BuildKubeControllerManagerComponen
 			kubeControllerManagerArgs = append(kubeControllerManagerArgs,
 				"--bind-address="+conf.BindAddress,
 				"--secure-port=10257",
-				"--tls-cert-file=/etc/kubernetes/pki/kube-controller-manager.crt", // Add argument for kube-controller-manager specific cert
+				"--tls-cert-file=/etc/kubernetes/pki/kube-controller-manager.crt",        // Add argument for kube-controller-manager specific cert
 				"--tls-private-key-file=/etc/kubernetes/pki/kube-controller-manager.key", // Add argument for kube-controller-manager specific key
 			)
 			if conf.Port > 0 {
@@ -145,7 +145,7 @@ func BuildKubeControllerManagerComponent(conf BuildKubeControllerManagerComponen
 			kubeControllerManagerArgs = append(kubeControllerManagerArgs,
 				"--bind-address="+conf.BindAddress,
 				"--secure-port="+format.String(conf.Port),
-				"--tls-cert-file="+conf.KubeControllerManagerCertPath, // Add argument for kube-controller-manager specific cert
+				"--tls-cert-file="+conf.KubeControllerManagerCertPath,       // Add argument for kube-controller-manager specific cert
 				"--tls-private-key-file="+conf.KubeControllerManagerKeyPath, // Add argument for kube-controller-manager specific key
 			)
 			metric = &internalversion.ComponentMetric{
@@ -153,7 +153,7 @@ func BuildKubeControllerManagerComponent(conf BuildKubeControllerManagerComponen
 				Host:               net.LocalAddress + ":" + format.String(conf.Port),
 				Path:               "/metrics",
 				CertPath:           conf.KubeControllerManagerCertPath, // Update metric to use kube-controller-manager specific cert
-				KeyPath:            conf.KubeControllerManagerKeyPath, // Update metric to use kube-controller-manager specific key
+				KeyPath:            conf.KubeControllerManagerKeyPath,  // Update metric to use kube-controller-manager specific key
 				InsecureSkipVerify: true,
 			}
 		}

--- a/pkg/kwokctl/runtime/binary/cluster.go
+++ b/pkg/kwokctl/runtime/binary/cluster.go
@@ -129,23 +129,23 @@ func (c *Cluster) setupPorts(ctx context.Context, used sets.Sets[uint32], ports 
 }
 
 type env struct {
-	kwokctlConfig           *internalversion.KwokctlConfiguration
-	verbosity               log.Level
-	inClusterKubeconfigPath string
-	kubeconfigPath          string
-	etcdDataPath            string
-	kwokConfigPath          string
-	pkiPath                 string
-	auditLogPath            string
-	auditPolicyPath         string
-	workdir                 string
-	caCertPath              string
-	adminKeyPath            string
-	adminCertPath           string
+	kwokctlConfig                 *internalversion.KwokctlConfiguration
+	verbosity                     log.Level
+	inClusterKubeconfigPath       string
+	kubeconfigPath                string
+	etcdDataPath                  string
+	kwokConfigPath                string
+	pkiPath                       string
+	auditLogPath                  string
+	auditPolicyPath               string
+	workdir                       string
+	caCertPath                    string
+	adminKeyPath                  string
+	adminCertPath                 string
 	kubeControllerManagerCertPath string
 	kubeControllerManagerKeyPath  string
-	scheme                  string
-	usedPorts               sets.Sets[uint32]
+	scheme                        string
+	usedPorts                     sets.Sets[uint32]
 }
 
 func (c *Cluster) env(ctx context.Context) (*env, error) {
@@ -189,23 +189,23 @@ func (c *Cluster) env(ctx context.Context) (*env, error) {
 	usedPorts := runtime.GetUsedPorts(ctx)
 
 	return &env{
-		kwokctlConfig:           config,
-		verbosity:               verbosity,
-		inClusterKubeconfigPath: inClusterKubeconfigPath,
-		kubeconfigPath:          kubeconfigPath,
-		etcdDataPath:            etcdDataPath,
-		kwokConfigPath:          kwokConfigPath,
-		pkiPath:                 pkiPath,
-		auditLogPath:            auditLogPath,
-		auditPolicyPath:         auditPolicyPath,
-		workdir:                 workdir,
-		caCertPath:              caCertPath,
-		adminKeyPath:            adminKeyPath,
-		adminCertPath:           adminCertPath,
-		kubeControllerManagerKeyPath: kubeControllerManagerKeyPath,
+		kwokctlConfig:                 config,
+		verbosity:                     verbosity,
+		inClusterKubeconfigPath:       inClusterKubeconfigPath,
+		kubeconfigPath:                kubeconfigPath,
+		etcdDataPath:                  etcdDataPath,
+		kwokConfigPath:                kwokConfigPath,
+		pkiPath:                       pkiPath,
+		auditLogPath:                  auditLogPath,
+		auditPolicyPath:               auditPolicyPath,
+		workdir:                       workdir,
+		caCertPath:                    caCertPath,
+		adminKeyPath:                  adminKeyPath,
+		adminCertPath:                 adminCertPath,
+		kubeControllerManagerKeyPath:  kubeControllerManagerKeyPath,
 		kubeControllerManagerCertPath: kubeControllerManagerCertPath,
-		scheme:                  scheme,
-		usedPorts:               usedPorts,
+		scheme:                        scheme,
+		usedPorts:                     usedPorts,
 	}, nil
 }
 

--- a/pkg/kwokctl/runtime/binary/cluster.go
+++ b/pkg/kwokctl/runtime/binary/cluster.go
@@ -142,6 +142,8 @@ type env struct {
 	caCertPath              string
 	adminKeyPath            string
 	adminCertPath           string
+	kubeControllerManagerCertPath string
+	kubeControllerManagerKeyPath  string
 	scheme                  string
 	usedPorts               sets.Sets[uint32]
 }
@@ -171,6 +173,8 @@ func (c *Cluster) env(ctx context.Context) (*env, error) {
 	caCertPath := path.Join(pkiPath, "ca.crt")
 	adminKeyPath := path.Join(pkiPath, "admin.key")
 	adminCertPath := path.Join(pkiPath, "admin.crt")
+	kubeControllerManagerKeyPath := path.Join(pkiPath, "kube-controller-manager.key")
+	kubeControllerManagerCertPath := path.Join(pkiPath, "kube-controller-manager.crt")
 	auditLogPath := ""
 	auditPolicyPath := ""
 
@@ -198,6 +202,8 @@ func (c *Cluster) env(ctx context.Context) (*env, error) {
 		caCertPath:              caCertPath,
 		adminKeyPath:            adminKeyPath,
 		adminCertPath:           adminCertPath,
+		kubeControllerManagerKeyPath: kubeControllerManagerKeyPath,
+		kubeControllerManagerCertPath: kubeControllerManagerCertPath,
 		scheme:                  scheme,
 		usedPorts:               usedPorts,
 	}, nil
@@ -482,6 +488,8 @@ func (c *Cluster) addKubeControllerManager(ctx context.Context, env *env) (err e
 			CaCertPath:                         env.caCertPath,
 			AdminCertPath:                      env.adminCertPath,
 			AdminKeyPath:                       env.adminKeyPath,
+			KubeControllerManagerCertPath:      env.kubeControllerManagerCertPath, // Add path for kube-controller-manager cert
+			KubeControllerManagerKeyPath:       env.kubeControllerManagerKeyPath,
 			KubeAuthorization:                  conf.KubeAuthorization,
 			KubeconfigPath:                     env.inClusterKubeconfigPath,
 			KubeFeatureGates:                   conf.KubeFeatureGates,

--- a/pkg/kwokctl/runtime/compose/cluster.go
+++ b/pkg/kwokctl/runtime/compose/cluster.go
@@ -184,10 +184,14 @@ type env struct {
 	caCertPath                    string
 	adminKeyPath                  string
 	adminCertPath                 string
+	kubeControllerManagerCertPath string
+	kubeControllerManagerKeyPath  string
 	inClusterPkiPath              string
 	inClusterCaCertPath           string
 	inClusterAdminKeyPath         string
 	inClusterAdminCertPath        string
+	inClusterkubeControllerManagerCertPath       string
+	inClusterkubeControllerManagerKeyPath       string
 	inClusterPort                 uint32
 	scheme                        string
 	usedPorts                     sets.Sets[uint32]
@@ -220,6 +224,8 @@ func (c *Cluster) env(ctx context.Context) (*env, error) {
 	inClusterCaCertPath := path.Join(inClusterPkiPath, "ca.crt")
 	inClusterAdminKeyPath := path.Join(inClusterPkiPath, "admin.key")
 	inClusterAdminCertPath := path.Join(inClusterPkiPath, "admin.crt")
+	inClusterkubeControllerManagerCertPath := path.Join(inClusterPkiPath, "kube-controller-manager.crt")
+	inClusterkubeControllerManagerKeyPath  := path.Join(inClusterPkiPath, "kube-controller-manager.key")
 
 	inClusterPort := uint32(8080)
 	scheme := "http"
@@ -252,6 +258,8 @@ func (c *Cluster) env(ctx context.Context) (*env, error) {
 		inClusterCaCertPath:           inClusterCaCertPath,
 		inClusterAdminKeyPath:         inClusterAdminKeyPath,
 		inClusterAdminCertPath:        inClusterAdminCertPath,
+		inClusterkubeControllerManagerCertPath: inClusterkubeControllerManagerCertPath,
+		inClusterkubeControllerManagerKeyPath: inClusterkubeControllerManagerKeyPath,
 		inClusterPort:                 inClusterPort,
 		scheme:                        scheme,
 		usedPorts:                     usedPorts,
@@ -501,6 +509,8 @@ func (c *Cluster) addKubeControllerManager(ctx context.Context, env *env) (err e
 			CaCertPath:                         env.caCertPath,
 			AdminCertPath:                      env.adminCertPath,
 			AdminKeyPath:                       env.adminKeyPath,
+			KubeControllerManagerCertPath: env.kubeControllerManagerCertPath,
+			KubeControllerManagerKeyPath: env.kubeControllerManagerKeyPath,
 			KubeAuthorization:                  conf.KubeAuthorization,
 			KubeconfigPath:                     env.inClusterOnHostKubeconfigPath,
 			KubeFeatureGates:                   conf.KubeFeatureGates,

--- a/pkg/kwokctl/runtime/kind/cluster.go
+++ b/pkg/kwokctl/runtime/kind/cluster.go
@@ -586,8 +586,8 @@ func (c *Cluster) addKubeControllerManager(_ context.Context, env *env) (err err
 				Scheme:             "https",
 				Host:               "127.0.0.1:10257",
 				Path:               "/metrics",
-				CertPath:           "/etc/kubernetes/pki/admin.crt",
-				KeyPath:            "/etc/kubernetes/pki/admin.key",
+				CertPath:           "/etc/kubernetes/pki/kube-controller-manager.crt",
+				KeyPath:            "/etc/kubernetes/pki/kube-controller-manager.key",
 				InsecureSkipVerify: true,
 			},
 		})


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind feature
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
Currently, all components of `kwokctl`(etcd, kube-apiserver, kube-controller-manager, kwok-controller) share admin certificates, which is different from kubeadm's behavior, and we try to close to kubeadm's behavior as much as possible. So I tried to generate a component-specific certificate for `kube-controller-manager ` component for kind and binary runtime for now. 

After the review I will successfully add the certificates for all the remaining components covering other runtimes also.
#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #878 

#### Special notes for your reviewer:
Hi @wzshiming I need a quick review on this implementation as I am going to add component-sepcific certs for other `kwokctl` components that are presently sharing admin cert.


