### PR TITLE
Add field of override for component extraArgs

### DIFF
--- a/pkg/apis/config/v1alpha1/kwokctl_configuration_types.go
+++ b/pkg/apis/config/v1alpha1/kwokctl_configuration_types.go
@@ -61,6 +61,8 @@ type ExtraArgs struct {
 	Key string `json:"key"`
 	// Value is the value of the extra args.
 	Value string `json:"value"`
+	// Override is the value of is it override the arg
+	Override bool `json:"override"`
 }
 
 // ComponentPatches holds information about the component patches.

--- a/pkg/apis/internalversion/kwokctl_configuration_types.go
+++ b/pkg/apis/internalversion/kwokctl_configuration_types.go
@@ -47,6 +47,8 @@ type ExtraArgs struct {
 	Key string
 	// Value is the value of the extra args.
 	Value string
+	// Override is the value of is it override the arg
+	Override bool
 }
 
 // ComponentPatches holds information about the component patches.

--- a/pkg/apis/internalversion/zz_generated.conversion.go
+++ b/pkg/apis/internalversion/zz_generated.conversion.go
@@ -1350,6 +1350,7 @@ func Convert_v1alpha1_ExpressionFromSource_To_internalversion_ExpressionFromSour
 func autoConvert_internalversion_ExtraArgs_To_v1alpha1_ExtraArgs(in *ExtraArgs, out *configv1alpha1.ExtraArgs, s conversion.Scope) error {
 	out.Key = in.Key
 	out.Value = in.Value
+	out.Override = in.Override
 	return nil
 }
 
@@ -1361,6 +1362,7 @@ func Convert_internalversion_ExtraArgs_To_v1alpha1_ExtraArgs(in *ExtraArgs, out 
 func autoConvert_v1alpha1_ExtraArgs_To_internalversion_ExtraArgs(in *configv1alpha1.ExtraArgs, out *ExtraArgs, s conversion.Scope) error {
 	out.Key = in.Key
 	out.Value = in.Value
+	out.Override = in.Override
 	return nil
 }
 

--- a/pkg/kwokctl/runtime/binary/cluster.go
+++ b/pkg/kwokctl/runtime/binary/cluster.go
@@ -731,7 +731,7 @@ func (c *Cluster) finishInstall(ctx context.Context, env *env) error {
 	conf := &env.kwokctlConfig.Options
 
 	for i := range env.kwokctlConfig.Components {
-		runtime.ApplyComponentPatches(&env.kwokctlConfig.Components[i], env.kwokctlConfig.ComponentsPatches)
+		runtime.ApplyComponentPatches(ctx, &env.kwokctlConfig.Components[i], env.kwokctlConfig.ComponentsPatches)
 	}
 
 	// Setup kubeconfig

--- a/pkg/kwokctl/runtime/compose/cluster.go
+++ b/pkg/kwokctl/runtime/compose/cluster.go
@@ -810,7 +810,7 @@ func (c *Cluster) finishInstall(ctx context.Context, env *env) error {
 	conf := &env.kwokctlConfig.Options
 
 	for i := range env.kwokctlConfig.Components {
-		runtime.ApplyComponentPatches(&env.kwokctlConfig.Components[i], env.kwokctlConfig.ComponentsPatches)
+		runtime.ApplyComponentPatches(ctx, &env.kwokctlConfig.Components[i], env.kwokctlConfig.ComponentsPatches)
 	}
 
 	// Setup kubeconfig

--- a/pkg/kwokctl/runtime/kind/cluster.go
+++ b/pkg/kwokctl/runtime/kind/cluster.go
@@ -561,7 +561,7 @@ func (c *Cluster) addKubectlProxy(ctx context.Context, env *env) (err error) {
 			return err
 		}
 
-		runtime.ApplyComponentPatches(&kubectlProxyComponent, env.kwokctlConfig.ComponentsPatches)
+		runtime.ApplyComponentPatches(ctx, &kubectlProxyComponent, env.kwokctlConfig.ComponentsPatches)
 
 		dashboardPod, err := yaml.Marshal(components.ConvertToPod(kubectlProxyComponent))
 		if err != nil {
@@ -654,7 +654,7 @@ func (c *Cluster) addKwokController(ctx context.Context, env *env) (err error) {
 	})
 	kwokControllerComponent.Volumes = append(kwokControllerComponent.Volumes, logVolumes...)
 
-	runtime.ApplyComponentPatches(&kwokControllerComponent, env.kwokctlConfig.ComponentsPatches)
+	runtime.ApplyComponentPatches(ctx, &kwokControllerComponent, env.kwokctlConfig.ComponentsPatches)
 
 	pod := components.ConvertToPod(kwokControllerComponent)
 	pod.Spec.Containers[0].Env = append(pod.Spec.Containers[0].Env, corev1.EnvVar{
@@ -709,7 +709,7 @@ func (c *Cluster) addDashboard(ctx context.Context, env *env) (err error) {
 			return fmt.Errorf("failed to build dashboard component: %w", err)
 		}
 
-		runtime.ApplyComponentPatches(&dashboardComponent, env.kwokctlConfig.ComponentsPatches)
+		runtime.ApplyComponentPatches(ctx, &dashboardComponent, env.kwokctlConfig.ComponentsPatches)
 
 		dashboardPod, err := yaml.Marshal(components.ConvertToPod(dashboardComponent))
 		if err != nil {
@@ -859,7 +859,7 @@ func (c *Cluster) addPrometheus(ctx context.Context, env *env) (err error) {
 			},
 		)
 
-		runtime.ApplyComponentPatches(&prometheusComponent, env.kwokctlConfig.ComponentsPatches)
+		runtime.ApplyComponentPatches(ctx, &prometheusComponent, env.kwokctlConfig.ComponentsPatches)
 
 		prometheusPod, err := yaml.Marshal(components.ConvertToPod(prometheusComponent))
 		if err != nil {
@@ -901,7 +901,7 @@ func (c *Cluster) addJaeger(ctx context.Context, env *env) (err error) {
 			return err
 		}
 
-		runtime.ApplyComponentPatches(&jaegerComponent, env.kwokctlConfig.ComponentsPatches)
+		runtime.ApplyComponentPatches(ctx, &jaegerComponent, env.kwokctlConfig.ComponentsPatches)
 
 		jaegerPod, err := yaml.Marshal(components.ConvertToPod(jaegerComponent))
 		if err != nil {

--- a/pkg/kwokctl/runtime/util_test.go
+++ b/pkg/kwokctl/runtime/util_test.go
@@ -1,0 +1,134 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package runtime
+
+import (
+	"context"
+	"reflect"
+	"testing"
+
+	"sigs.k8s.io/kwok/pkg/apis/internalversion"
+)
+
+func TestApplyComponentArgsOverride(t *testing.T) {
+	tests := []struct {
+		name     string
+		args     []string
+		patch    internalversion.ExtraArgs
+		wantArgs []string
+	}{
+		{
+			name: "Override the value",
+			args: []string{
+				"--foo=1",
+				"--bar=2",
+			},
+			patch: internalversion.ExtraArgs{
+				Key:      "foo",
+				Value:    "10",
+				Override: true,
+			},
+			wantArgs: []string{
+				"--foo=10",
+				"--bar=2",
+			},
+		},
+		{
+			name: "Unmatched flag",
+			args: []string{
+				"--foo=1",
+			},
+			patch: internalversion.ExtraArgs{
+				Key:      "bar",
+				Value:    "2",
+				Override: true,
+			},
+			wantArgs: []string{
+				"--foo=1",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			applyComponentArgsOverride(context.TODO(), tt.args, internalversion.ExtraArgs{
+				Key:      tt.patch.Key,
+				Value:    tt.patch.Value,
+				Override: tt.patch.Override,
+			})
+
+			if !reflect.DeepEqual(tt.wantArgs, tt.args) {
+				t.Errorf("Exist is not expact! key:%s want args:%s, got args:%s", tt.patch.Key, tt.wantArgs, tt.args)
+			}
+		})
+	}
+}
+
+func TestApplyComponentPatch(t *testing.T) {
+	tests := []struct {
+		name      string
+		component internalversion.Component
+		patch     internalversion.ComponentPatches
+		wantArgs  []string
+	}{
+		{
+			name: "Override the value",
+			component: internalversion.Component{
+				Name: "test",
+				Args: []string{"--etcd-servers=http://localhost:2379", "--etcd-prefix=/registry"},
+			},
+			patch: internalversion.ComponentPatches{
+				Name: "test",
+				ExtraArgs: []internalversion.ExtraArgs{
+					{
+						Key:      "etcd-servers",
+						Value:    "http://127.0.0.1:2379",
+						Override: true,
+					},
+				},
+			},
+			wantArgs: []string{"--etcd-servers=http://127.0.0.1:2379", "--etcd-prefix=/registry"},
+		},
+		{
+			name: "Do not override the value",
+			component: internalversion.Component{
+				Name: "test",
+				Args: []string{"--etcd-servers=http://localhost:2379", "--etcd-prefix=/registry"},
+			},
+			patch: internalversion.ComponentPatches{
+				Name: "test",
+				ExtraArgs: []internalversion.ExtraArgs{
+					{
+						Key:      "etcd-servers",
+						Value:    "http://127.0.0.1:2379",
+						Override: false,
+					},
+				},
+			},
+			wantArgs: []string{"--etcd-servers=http://localhost:2379", "--etcd-prefix=/registry", "--etcd-servers=http://127.0.0.1:2379"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			applyComponentPatch(context.TODO(), &tt.component, tt.patch)
+			if !reflect.DeepEqual(tt.wantArgs, tt.component.Args) {
+				t.Errorf("Exist is not expact! key:%s want args:%s, got args:%s", tt.patch.ExtraArgs[0].Key, tt.wantArgs, tt.component.Args)
+			}
+		})
+	}
+}

--- a/site/content/en/docs/generated/apis.md
+++ b/site/content/en/docs/generated/apis.md
@@ -2264,6 +2264,17 @@ string
 <p>Value is the value of the extra args.</p>
 </td>
 </tr>
+<tr>
+<td>
+<code>override</code>
+<em>
+bool
+</em>
+</td>
+<td>
+<p>Override is the value of is it override the arg</p>
+</td>
+</tr>
 </tbody>
 </table>
 <h3 id="config.kwok.x-k8s.io/v1alpha1.HostPathType">


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind cleanup
#### What this PR does / why we need it:

I'm using componentsPatches to rewrite the args of kube-apiserver for `etcd-servers` and `etcd-prefix`, it's working for me but i found the arg etcd-servers and etcd-prefix is repeated. This PR is working for cleanup the repeate.

config.yaml
```yaml
kind: KwokctlConfiguration
apiVersion: config.kwok.x-k8s.io/v1alpha1
componentsPatches:
- name: kube-apiserver
  extraArgs:
  - key: etcd-servers
    value: http://192.168.66.2:3379
  - key: etcd-prefix
    value: /test

```

cmd of container kube-apiserver
```shell
                "--etcd-prefix=/registry",
                "--allow-privileged=true",
                "--etcd-servers=http://kwok-kwok-etcd:2379",
...
                "--etcd-servers=http://192.168.66.2:3379",
                "--etcd-prefix=/test"
```

/assign @wzshiming 

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
support override filed for extraArg.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
