### PR TITLE
make GetUnusedPort concurrency safe

### DIFF
--- a/pkg/utils/net/unused_port.go
+++ b/pkg/utils/net/unused_port.go
@@ -20,17 +20,21 @@ import (
 	"context"
 	"fmt"
 	"net"
+	"sync"
 
 	"sigs.k8s.io/kwok/pkg/utils/sets"
 )
 
 var (
-	errGetUnusedPort        = fmt.Errorf("unable to get an unused port")
+	errGetUnusedPort = fmt.Errorf("unable to get an unused port")
+	unusedPortSync   sync.Mutex
 	lastUsedPort     uint32 = 32767
 )
 
 // GetUnusedPort returns an unused port on the local machine.
 func GetUnusedPort(ctx context.Context, used sets.Sets[uint32]) (uint32, error) {
+	unusedPortSync.Lock()
+	defer unusedPortSync.Unlock()
 	for lastUsedPort > 10000 && ctx.Err() == nil {
 		lastUsedPort--
 		if used.Has(lastUsedPort) {


### PR DESCRIPTION
#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:
Kwok can be used nicely in go test with parallelism. However when running with -race, GetUnusedPort is flagged as a data race. Ancedotally, during our tests we have seen port contention and this might help resolve that.

#### Which issue(s) this PR fixes:

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
