### PR TITLE
add flag --etcd-quota-backend-size

### DIFF
--- a/pkg/apis/config/v1alpha1/kwokctl_configuration_types.go
+++ b/pkg/apis/config/v1alpha1/kwokctl_configuration_types.go
@@ -452,6 +452,10 @@ type KwokctlConfigurationOptions struct {
 	// DisableQPSLimits specifies whether to disable QPS limits for components.
 	// +default=false
 	DisableQPSLimits *bool `json:"disableQPSLimits,omitempty"`
+
+	// EtcdQuotaBackendSize is the backend quota for etcd.
+	// +default="8Gi"
+	EtcdQuotaBackendSize string `json:"etcdQuotaBackendSize,omitempty"`
 }
 
 // Component is a component of the cluster.

--- a/pkg/apis/config/v1alpha1/zz_generated.defaults.go
+++ b/pkg/apis/config/v1alpha1/zz_generated.defaults.go
@@ -112,6 +112,9 @@ func SetObjectDefaults_KwokctlConfiguration(in *KwokctlConfiguration) {
 		var ptrVar1 bool = false
 		in.Options.DisableQPSLimits = &ptrVar1
 	}
+	if in.Options.EtcdQuotaBackendSize == "" {
+		in.Options.EtcdQuotaBackendSize = "8Gi"
+	}
 	for i := range in.Components {
 		a := &in.Components[i]
 		for j := range a.Ports {

--- a/pkg/apis/internalversion/kwokctl_configuration_types.go
+++ b/pkg/apis/internalversion/kwokctl_configuration_types.go
@@ -295,6 +295,9 @@ type KwokctlConfigurationOptions struct {
 
 	// DisableQPSLimits specifies whether to disable QPS limits for components.
 	DisableQPSLimits bool
+
+	// EtcdQuotaBackendSize is the backend quota for etcd.
+	EtcdQuotaBackendSize string
 }
 
 // Component is a component of the cluster.

--- a/pkg/apis/internalversion/zz_generated.conversion.go
+++ b/pkg/apis/internalversion/zz_generated.conversion.go
@@ -1735,6 +1735,7 @@ func autoConvert_internalversion_KwokctlConfigurationOptions_To_v1alpha1_Kwokctl
 	if err := v1.Convert_bool_To_Pointer_bool(&in.DisableQPSLimits, &out.DisableQPSLimits, s); err != nil {
 		return err
 	}
+	out.EtcdQuotaBackendSize = in.EtcdQuotaBackendSize
 	return nil
 }
 
@@ -1851,6 +1852,7 @@ func autoConvert_v1alpha1_KwokctlConfigurationOptions_To_internalversion_Kwokctl
 	if err := v1.Convert_Pointer_bool_To_bool(&in.DisableQPSLimits, &out.DisableQPSLimits, s); err != nil {
 		return err
 	}
+	out.EtcdQuotaBackendSize = in.EtcdQuotaBackendSize
 	return nil
 }
 

--- a/pkg/kwokctl/cmd/create/cluster/cluster.go
+++ b/pkg/kwokctl/cmd/create/cluster/cluster.go
@@ -143,6 +143,7 @@ func NewCommand(ctx context.Context) *cobra.Command {
 	cmd.Flags().StringSliceVar(&flags.Options.EnableCRDs, "enable-crds", flags.Options.EnableCRDs, "List of CRDs to enable")
 	cmd.Flags().UintVar(&flags.Options.NodeLeaseDurationSeconds, "node-lease-duration-seconds", flags.Options.NodeLeaseDurationSeconds, "Duration of node lease in seconds")
 	cmd.Flags().Float64Var(&flags.Options.HeartbeatFactor, "heartbeat-factor", flags.Options.HeartbeatFactor, "Scale factor for all about heartbeat")
+	cmd.Flags().StringVar(&flags.Options.EtcdQuotaBackendSize, "etcd-quota-backend-size", flags.Options.EtcdQuotaBackendSize, "Quota backend size for etcd")
 	cmd.Flags().StringArrayVar(&flags.ExtraArgs, "extra-args", flags.ExtraArgs, "Pass a single extra arg key-value pair to the component in the format `component=key=value`")
 
 	return cmd

--- a/pkg/kwokctl/runtime/binary/cluster.go
+++ b/pkg/kwokctl/runtime/binary/cluster.go
@@ -328,16 +328,17 @@ func (c *Cluster) addEtcd(ctx context.Context, env *env) (err error) {
 	}
 
 	etcdComponent, err := components.BuildEtcdComponent(components.BuildEtcdComponentConfig{
-		Runtime:     conf.Runtime,
-		ProjectName: c.Name(),
-		Workdir:     env.workdir,
-		Binary:      etcdPath,
-		Version:     etcdVersion,
-		BindAddress: conf.BindAddress,
-		DataPath:    env.etcdDataPath,
-		Port:        conf.EtcdPort,
-		PeerPort:    conf.EtcdPeerPort,
-		Verbosity:   env.verbosity,
+		Runtime:          conf.Runtime,
+		ProjectName:      c.Name(),
+		Workdir:          env.workdir,
+		Binary:           etcdPath,
+		Version:          etcdVersion,
+		BindAddress:      conf.BindAddress,
+		DataPath:         env.etcdDataPath,
+		Port:             conf.EtcdPort,
+		PeerPort:         conf.EtcdPeerPort,
+		Verbosity:        env.verbosity,
+		QuotaBackendSize: conf.EtcdQuotaBackendSize,
 	})
 	if err != nil {
 		return err

--- a/pkg/kwokctl/runtime/compose/cluster.go
+++ b/pkg/kwokctl/runtime/compose/cluster.go
@@ -365,15 +365,16 @@ func (c *Cluster) addEtcd(ctx context.Context, env *env) (err error) {
 	}
 
 	etcdComponent, err := components.BuildEtcdComponent(components.BuildEtcdComponentConfig{
-		Runtime:     conf.Runtime,
-		ProjectName: c.Name(),
-		Workdir:     env.workdir,
-		Image:       conf.EtcdImage,
-		Version:     etcdVersion,
-		BindAddress: net.PublicAddress,
-		Port:        conf.EtcdPort,
-		DataPath:    env.etcdDataPath,
-		Verbosity:   env.verbosity,
+		Runtime:          conf.Runtime,
+		ProjectName:      c.Name(),
+		Workdir:          env.workdir,
+		Image:            conf.EtcdImage,
+		Version:          etcdVersion,
+		BindAddress:      net.PublicAddress,
+		Port:             conf.EtcdPort,
+		DataPath:         env.etcdDataPath,
+		Verbosity:        env.verbosity,
+		QuotaBackendSize: conf.EtcdQuotaBackendSize,
 	})
 	if err != nil {
 		return err

--- a/pkg/kwokctl/runtime/kind/cluster.go
+++ b/pkg/kwokctl/runtime/kind/cluster.go
@@ -472,6 +472,7 @@ func (c *Cluster) addKind(ctx context.Context, env *env) (err error) {
 		PrometheusExtraVolumes:        prometheusPatches.ExtraVolumes,
 		DisableQPSLimits:              conf.DisableQPSLimits,
 		KubeVersion:                   kubeVersion,
+		EtcdQuotaBackendSize:          conf.EtcdQuotaBackendSize,
 	})
 	if err != nil {
 		return err

--- a/site/content/en/docs/generated/apis.md
+++ b/site/content/en/docs/generated/apis.md
@@ -3702,6 +3702,17 @@ bool
 <p>DisableQPSLimits specifies whether to disable QPS limits for components.</p>
 </td>
 </tr>
+<tr>
+<td>
+<code>etcdQuotaBackendSize</code>
+<em>
+string
+</em>
+</td>
+<td>
+<p>EtcdQuotaBackendSize is the backend quota for etcd.</p>
+</td>
+</tr>
 </tbody>
 </table>
 <h3 id="config.kwok.x-k8s.io/v1alpha1.KwokctlConfigurationStatus">

--- a/site/content/en/docs/generated/kwokctl_create_cluster.md
+++ b/site/content/en/docs/generated/kwokctl_create_cluster.md
@@ -25,6 +25,7 @@ kwokctl create cluster [flags]
                                                  (default "registry.k8s.io/etcd:3.5.15-0")
       --etcd-port uint32                        Port of etcd given to the host. The behavior is unstable for kind/kind-podman runtime and may be modified in the future
       --etcd-prefix string                      prefix of the key (default "/registry")
+      --etcd-quota-backend-size string          Quota backend size for etcd (default "8Gi")
       --extra-args component=key=value          Pass a single extra arg key-value pair to the component in the format component=key=value
       --heartbeat-factor float                  Scale factor for all about heartbeat (default 5)
   -h, --help                                    help for cluster

--- a/test/e2e/kwokctl/dryrun/testdata/kind-podman/create_cluster.txt
+++ b/test/e2e/kwokctl/dryrun/testdata/kind-podman/create_cluster.txt
@@ -25,6 +25,8 @@ kubeadmConfigPatches:
   etcd:
     local:
       dataDir: /var/lib/etcd
+      extraArgs:
+        quota-backend-bytes: "8589934592"
   kind: ClusterConfiguration
   networking: {}
   scheduler:

--- a/test/e2e/kwokctl/dryrun/testdata/kind-podman/create_cluster_with_extra.txt
+++ b/test/e2e/kwokctl/dryrun/testdata/kind-podman/create_cluster_with_extra.txt
@@ -39,6 +39,7 @@ kubeadmConfigPatches:
       dataDir: /var/lib/etcd
       extraArgs:
         log-level: debug
+        quota-backend-bytes: "8589934592"
   kind: ClusterConfiguration
   networking: {}
   scheduler:

--- a/test/e2e/kwokctl/dryrun/testdata/kind-podman/create_cluster_with_verbosity.txt
+++ b/test/e2e/kwokctl/dryrun/testdata/kind-podman/create_cluster_with_verbosity.txt
@@ -57,6 +57,8 @@ kubeadmConfigPatches:
   etcd:
     local:
       dataDir: /var/lib/etcd
+      extraArgs:
+        quota-backend-bytes: "8589934592"
   kind: ClusterConfiguration
   networking: {}
   scheduler:

--- a/test/e2e/kwokctl/dryrun/testdata/kind/create_cluster.txt
+++ b/test/e2e/kwokctl/dryrun/testdata/kind/create_cluster.txt
@@ -25,6 +25,8 @@ kubeadmConfigPatches:
   etcd:
     local:
       dataDir: /var/lib/etcd
+      extraArgs:
+        quota-backend-bytes: "8589934592"
   kind: ClusterConfiguration
   networking: {}
   scheduler:

--- a/test/e2e/kwokctl/dryrun/testdata/kind/create_cluster_with_extra.txt
+++ b/test/e2e/kwokctl/dryrun/testdata/kind/create_cluster_with_extra.txt
@@ -39,6 +39,7 @@ kubeadmConfigPatches:
       dataDir: /var/lib/etcd
       extraArgs:
         log-level: debug
+        quota-backend-bytes: "8589934592"
   kind: ClusterConfiguration
   networking: {}
   scheduler:

--- a/test/e2e/kwokctl/dryrun/testdata/kind/create_cluster_with_verbosity.txt
+++ b/test/e2e/kwokctl/dryrun/testdata/kind/create_cluster_with_verbosity.txt
@@ -57,6 +57,8 @@ kubeadmConfigPatches:
   etcd:
     local:
       dataDir: /var/lib/etcd
+      extraArgs:
+        quota-backend-bytes: "8589934592"
   kind: ClusterConfiguration
   networking: {}
   scheduler:


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/kind feature

#### What this PR does / why we need it:

Allows for controlling the quota size of etcd.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #864 
(ref #866 )

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
[kwokctl] Add flag --etcd-quota-backend-size
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
NONE
```
