### PR TITLE
Fix quantity scaling in cel calculations

### DIFF
--- a/pkg/kwok/metrics/evaluator_test.go
+++ b/pkg/kwok/metrics/evaluator_test.go
@@ -18,6 +18,7 @@ package metrics
 
 import (
 	"context"
+	"math"
 	"testing"
 	"time"
 
@@ -112,7 +113,9 @@ func TestResourceEvaluation(t *testing.T) {
 		t.Fatalf("evaluation failed: %v", err)
 	}
 
-	if actual != 18 {
-		t.Errorf("expected %v, got %v", 18, actual)
+	const epsilon = 1e-9
+	expected := 1.8
+	if math.Abs(actual-expected) > epsilon {
+		t.Errorf("expected %v, got %v", expected, actual)
 	}
 }

--- a/pkg/utils/cel/funcs_test.go
+++ b/pkg/utils/cel/funcs_test.go
@@ -1,0 +1,72 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cel
+
+import (
+	"testing"
+	"time"
+
+	"github.com/google/cel-go/common/types"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestTimeNow(t *testing.T) {
+	refVal := runAndCheckExpression(t, "Now()", types.TimestampType)
+
+	actual := refVal.Value().(time.Time)
+
+	if !expectedTime.Equal(actual) {
+		t.Errorf("expected %v, got %v", expectedTime, actual)
+	}
+}
+
+func TestMathRand(t *testing.T) {
+	refVal := runAndCheckExpression(t, "Rand()", types.DoubleType)
+	actual := refVal.Value().(float64)
+
+	if actual < 0 || actual > 1 {
+		t.Errorf("expected value between 0 and 1, got %v", refVal.Value())
+	}
+}
+
+func TestUnixSecond(t *testing.T) {
+	refVal := runAndCheckExpressionWithData(t, "UnixSecond(time)", map[string]any{
+		"time": expectedTime,
+	}, types.DoubleType)
+
+	actual := refVal.Value().(float64)
+	expected := float64(expectedTime.Unix())
+
+	compareFloat64(t, expected, actual)
+}
+
+func TestSinceSecond(t *testing.T) {
+	n := &corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			CreationTimestamp: metav1.Time{Time: expectedTime},
+		},
+	}
+	refVal := runAndCheckExpressionWithData(t, "SinceSecond(node)", map[string]any{
+		"node": n,
+	}, types.DoubleType)
+
+	actual := refVal.Value().(float64)
+	if actual < 0 {
+		t.Errorf("expected positive value, got %v", actual)
+	}
+}

--- a/pkg/utils/cel/quantity.go
+++ b/pkg/utils/cel/quantity.go
@@ -47,7 +47,7 @@ type Quantity struct {
 // NewQuantity creates a new Quantity
 func NewQuantity(q *resource.Quantity) Quantity {
 	if q == nil {
-		q = resource.NewScaledQuantity(0, resource.Nano)
+		q = resource.NewMilliQuantity(0, resource.DecimalSI)
 	}
 	return Quantity{Quantity: q}
 }
@@ -61,18 +61,18 @@ func NewQuantityFromString(s string) (Quantity, error) {
 	return NewQuantity(&r), nil
 }
 
-func newQuantityFromNanoInt64(v int64) Quantity {
-	r := resource.NewScaledQuantity(v, resource.Nano)
+func newQuantityFromMilliInt64(v int64) Quantity {
+	r := resource.NewMilliQuantity(v, resource.DecimalSI)
 	return NewQuantity(r)
 }
 
 func newQuantityFromFloat64(v float64) Quantity {
-	r := resource.NewScaledQuantity(int64(v*10e9), resource.Nano)
+	r := resource.NewMilliQuantity(int64(v*1e3), resource.DecimalSI)
 	return NewQuantity(r)
 }
 
-func (q Quantity) nano() int64 {
-	return q.Quantity.ScaledValue(resource.Nano)
+func (q Quantity) milli() int64 {
+	return q.Quantity.MilliValue()
 }
 
 func (q Quantity) float() float64 {
@@ -157,10 +157,10 @@ func (q Quantity) Divide(other ref.Val) ref.Val {
 	switch other.Type() {
 	case types.IntType:
 		otherInt := other.(types.Int)
-		return newQuantityFromNanoInt64(q.nano() / int64(otherInt))
+		return newQuantityFromMilliInt64(q.milli() / int64(otherInt))
 	case types.UintType:
 		otherUint := other.(types.Uint)
-		return newQuantityFromNanoInt64(q.nano() / int64(otherUint))
+		return newQuantityFromMilliInt64(q.milli() / int64(otherUint))
 	case types.DoubleType:
 		otherDouble := other.(types.Double)
 		return newQuantityFromFloat64(q.float() / float64(otherDouble))
@@ -174,10 +174,10 @@ func (q Quantity) Multiply(other ref.Val) ref.Val {
 	switch other.Type() {
 	case types.IntType:
 		otherInt := other.(types.Int)
-		return newQuantityFromNanoInt64(q.nano() * int64(otherInt))
+		return newQuantityFromMilliInt64(q.milli() * int64(otherInt))
 	case types.UintType:
 		otherUint := other.(types.Uint)
-		return newQuantityFromNanoInt64(q.nano() * int64(otherUint))
+		return newQuantityFromMilliInt64(q.milli() * int64(otherUint))
 	case types.DoubleType:
 		otherDouble := other.(types.Double)
 		return newQuantityFromFloat64(q.float() * float64(otherDouble))

--- a/pkg/utils/cel/quantity_test.go
+++ b/pkg/utils/cel/quantity_test.go
@@ -1,0 +1,297 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cel
+
+import (
+	"maps"
+	"math"
+	"testing"
+	"time"
+
+	"github.com/google/cel-go/common/types"
+	"github.com/google/cel-go/common/types/ref"
+	"k8s.io/apimachinery/pkg/api/resource"
+)
+
+var expectedTime = time.Date(2006, 1, 2, 15, 4, 5, 0, time.UTC)
+
+func TestQuantityCalculation(t *testing.T) {
+	tests := []struct {
+		name       string
+		expression string
+		expected   string
+	}{
+		{
+			name:       "parse tebibyte quantity",
+			expression: `Quantity("1Ti")`,
+			expected:   `1Ti`,
+		},
+		{
+			name:       "add tebibyte",
+			expression: `Quantity("1Ti") + Quantity("1Ti")`,
+			expected:   `2Ti`,
+		},
+		{
+			name:       "subtract gibibyte",
+			expression: `Quantity("1Ti") - Quantity("512Gi")`,
+			expected:   `512Gi`,
+		},
+		{
+			name:       "negate tebibyte",
+			expression: `-Quantity("1Ti")`,
+			expected:   `-1Ti`,
+		},
+		{
+			name:       "tebibyte multiply int",
+			expression: `Quantity("1Ti") * 2`,
+			expected:   `2Ti`,
+		},
+		{
+			name:       "tebibyte multiply uint",
+			expression: `Quantity("1Ti") * 2u`,
+			expected:   `2Ti`,
+		},
+		{
+			name:       "tebibyte multiply float",
+			expression: `Quantity("1Ti") * 0.5`,
+			expected:   `512Gi`,
+		},
+		{
+			name:       "tebibyte divide int",
+			expression: `Quantity("1Ti") / 2`,
+			expected:   `512Gi`,
+		},
+		{
+			name:       "tebibyte divide uint",
+			expression: `Quantity("1Ti") / 2u`,
+			expected:   `512Gi`,
+		},
+		{
+			name:       "tebibyte divide float",
+			expression: `Quantity("1Ti") / 2.0`,
+			expected:   `512Gi`,
+		},
+		{
+			name:       "parse millicpu quantity",
+			expression: `Quantity("1m")`,
+			expected:   `1m`,
+		},
+		{
+			name:       "millicpu multiply int",
+			expression: `Quantity("1m") * 2`,
+			expected:   `2m`,
+		},
+		{
+			name:       "millicpu multiply float",
+			expression: `Quantity("1m") * 1.0`,
+			expected:   `1m`,
+		},
+		{
+			name:       "millicpu floor to zero",
+			expression: `Quantity("1m") * 0.5`,
+			expected:   `0`,
+		},
+		{
+			name:       "millicpu divide int",
+			expression: `Quantity("5m") / 2`,
+			expected:   `2m`,
+		},
+		{
+			name:       "millicpu divide float",
+			expression: `Quantity("1m") / 0.1`,
+			expected:   `10m`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			evaluateAndCompareToQuantity(t, tt.expression, tt.expected)
+		})
+	}
+}
+
+func TestQuantityCalculationError(t *testing.T) {
+	tests := []struct {
+		name       string
+		expression string
+	}{
+		{
+			name:       "millicpu add invalid int",
+			expression: `Quantity("1m") + 1`,
+		},
+		{
+			name:       "millicpu subtract invalid string",
+			expression: `Quantity("1m") - "1"`,
+		},
+		{
+			name:       "millicpu multiply invalid string",
+			expression: `Quantity("1m") * "2.0"`,
+		},
+		{
+			name:       "millicpu divide invalid string",
+			expression: `Quantity("5m") / "2"`,
+		},
+		{
+			name:       "millicpu divide by zero int",
+			expression: `Quantity("1m") / 0`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			evaluateAndShouldError(t, tt.expression)
+		})
+	}
+}
+
+func TestQuantityComparison(t *testing.T) {
+	tests := []struct {
+		name       string
+		expression string
+		expected   bool
+	}{
+		{
+			name:       "compare tebibyte",
+			expression: `Quantity("1Ti") == Quantity("1Ti")`,
+			expected:   true,
+		},
+		{
+			name:       "compare tebibyte to gibibyte",
+			expression: `Quantity("1Ti") == Quantity("1024Gi")`,
+			expected:   true,
+		},
+		{
+			name:       "compare tebibyte to gibibyte",
+			expression: `Quantity("1") != Quantity("1000m")`,
+			expected:   false,
+		},
+		{
+			name:       "compare tebibyte to gibibyte",
+			expression: `Quantity("1Ti") > Quantity("1024Gi")`,
+			expected:   false,
+		},
+		{
+			name:       "compare tebibyte to gibibyte",
+			expression: `Quantity("1Ti") < Quantity("1024Gi")`,
+			expected:   false,
+		},
+		{
+			name:       "compare tebibyte to gibibyte",
+			expression: `Quantity("1Ti") >= Quantity("1024Gi")`,
+			expected:   true,
+		},
+		{
+			name:       "compare tebibyte to gibibyte",
+			expression: `Quantity("1Ti") <= Quantity("1024Gi")`,
+			expected:   true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			evaluateAndCompareToBool(t, tt.expression, tt.expected)
+		})
+	}
+}
+
+func evaluateAndCompareToQuantity(t *testing.T, expression, expectedStr string) {
+	refVal, err := runExpression(t, expression)
+	if err != nil {
+		t.Errorf("failed to run CEL expression: %v", err)
+		return
+	}
+
+	actual, err := AsFloat64(refVal)
+	if err != nil {
+		t.Errorf("failed to convert to float64: %v", err)
+	}
+
+	expectedQuantity := resource.MustParse(expectedStr)
+	expected := expectedQuantity.AsApproximateFloat64()
+
+	compareFloat64(t, actual, expected)
+}
+
+func evaluateAndCompareToBool(t *testing.T, expression string, expected bool) {
+	refVal := runAndCheckExpression(t, expression, types.BoolType)
+
+	actual := refVal.Value().(bool)
+	if actual != expected {
+		t.Errorf("expected %v, got %v", expected, actual)
+	}
+}
+
+func evaluateAndShouldError(t *testing.T, expression string) {
+	_, err := runExpression(t, expression)
+	if err == nil {
+		t.Errorf("expected error, but got none")
+	}
+}
+
+func runAndCheckExpression(t *testing.T, expr string, expectedType ref.Type) ref.Val {
+	return runAndCheckExpressionWithData(t, expr, map[string]any{}, expectedType)
+}
+
+func runExpression(t *testing.T, expression string) (ref.Val, error) {
+	return runExpressionWithData(t, expression, map[string]any{})
+}
+
+func runAndCheckExpressionWithData(t *testing.T, expr string, data map[string]any, expectedType ref.Type) ref.Val {
+	refVal, err := runExpressionWithData(t, expr, data)
+	if err != nil {
+		t.Fatalf("unexpected error running expression %q with data %v: %v", expr, data, err)
+	}
+	if refVal.Type() != expectedType {
+		t.Fatalf("expected %v, got %v", expectedType, refVal.Type())
+	}
+	return refVal
+}
+
+func runExpressionWithData(t *testing.T, expression string, data map[string]any) (ref.Val, error) {
+	funcs := maps.Clone(DefaultFuncs)
+
+	// make Now() return a fixed value
+	funcs[nowName] = []any{func() time.Time {
+		return expectedTime
+	}}
+
+	env, err := NewEnvironment(EnvironmentConfig{
+		Types:       DefaultTypes,
+		Conversions: DefaultConversions,
+		Methods:     FuncsToMethods(funcs),
+		Funcs:       funcs,
+		Vars:        data,
+	})
+	if err != nil {
+		t.Fatalf("failed to instantiate node Evaluator: %v", err)
+	}
+
+	eval, err := env.Compile(expression)
+	if err != nil {
+		t.Fatalf("failed to compile expression: %v", err)
+	}
+
+	refVal, _, err := eval.Eval(data)
+	return refVal, err
+}
+
+func compareFloat64(t *testing.T, actual, expected float64) {
+	const epsilon = 1e-9
+	if math.Abs(actual-expected) > epsilon {
+		t.Errorf("expected %v, got %v", expected, actual)
+	}
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/kind bug

#### What this PR does / why we need it:

This Pull Request corrects inaccurate resource calculations in `ClusterResourceUsage` expressions by addressing a scaling issue in the `newQuantityFromFloat64` function, ensuring accurate resource usage results.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #1259
Fixes #1261

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Fix Quantity calculation
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
NONE
```
