### PR TITLE
test: Add test case for DurationFrom

### DIFF
--- a/pkg/utils/expression/value_duration_from_test.go
+++ b/pkg/utils/expression/value_duration_from_test.go
@@ -72,6 +72,18 @@ func TestDurationFrom_Get(t *testing.T) {
 			want:   1 * time.Second,
 			wantOk: true,
 		},
+		{
+			args: args{
+				src: format.Ptr(".metadata.annotations[\"custom-duration\"]"),
+				v: corev1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						Annotations: map[string]string{"custom-duration": "7s"},
+					},
+				},
+			},
+			want:   7 * time.Second,
+			wantOk: true,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
#### What type of PR is this?
/kind feature
/kind cleanup


#### What this PR does / why we need it:
This PR adds additional test cases for the `DurationFrom` feature to enhance test coverage. 

There is a second use of `DurationFrom` in the kwok document: specifying a specific time using a string type, but there is no test in the code for this case.

`DurationFrom is the expression used to get the value. If it is a time.Time type, getting the value will be minus time.Now() to get DurationMilliseconds If it is a string type, the value get will be parsed by time.ParseDuration.
`

link: https://kwok.sigs.k8s.io/docs/generated/apis/#kwok.x-k8s.io/v1alpha1.ExpressionFromSource


