### PR TITLE
Support for configuring previous container logs

### DIFF
--- a/kustomize/crd/bases/kwok.x-k8s.io_clusterlogs.yaml
+++ b/kustomize/crd/bases/kwok.x-k8s.io_clusterlogs.yaml
@@ -56,6 +56,10 @@ spec:
                       description: LogsFile is the file from which the log forward
                         starts
                       type: string
+                    previousLogsFile:
+                      description: PreviousLogsFile is the file containing previous
+                        container logs
+                      type: string
                   type: object
                 type: array
               selector:

--- a/kustomize/crd/bases/kwok.x-k8s.io_logs.yaml
+++ b/kustomize/crd/bases/kwok.x-k8s.io_logs.yaml
@@ -56,6 +56,10 @@ spec:
                       description: LogsFile is the file from which the log forward
                         starts
                       type: string
+                    previousLogsFile:
+                      description: PreviousLogsFile is the file containing previous
+                        container logs
+                      type: string
                   type: object
                 type: array
             required:

--- a/pkg/apis/internalversion/conversion.go
+++ b/pkg/apis/internalversion/conversion.go
@@ -193,6 +193,13 @@ func ConvertToInternalClusterLogs(in *v1alpha1.ClusterLogs) (*ClusterLogs, error
 				return nil, err
 			}
 		}
+		previousLogsFile := out.Spec.Logs[i].PreviousLogsFile
+		if previousLogsFile != "" {
+			out.Spec.Logs[i].PreviousLogsFile, err = path.Expand(previousLogsFile)
+			if err != nil {
+				return nil, err
+			}
+		}
 	}
 	return &out, nil
 }
@@ -254,6 +261,13 @@ func ConvertToInternalLogs(in *v1alpha1.Logs) (*Logs, error) {
 		logsFile := out.Spec.Logs[i].LogsFile
 		if logsFile != "" {
 			out.Spec.Logs[i].LogsFile, err = path.Expand(logsFile)
+			if err != nil {
+				return nil, err
+			}
+		}
+		previousLogsFile := out.Spec.Logs[i].PreviousLogsFile
+		if previousLogsFile != "" {
+			out.Spec.Logs[i].PreviousLogsFile, err = path.Expand(previousLogsFile)
 			if err != nil {
 				return nil, err
 			}

--- a/pkg/apis/internalversion/logs_types.go
+++ b/pkg/apis/internalversion/logs_types.go
@@ -41,6 +41,8 @@ type Log struct {
 	Containers []string
 	// LogsFile is the file from which the log forward starts
 	LogsFile string
+	// PreviousLogsFile is the file containing previous container logs
+	PreviousLogsFile string
 	// Follow up if true
 	Follow bool
 }

--- a/pkg/apis/internalversion/zz_generated.conversion.go
+++ b/pkg/apis/internalversion/zz_generated.conversion.go
@@ -1933,6 +1933,9 @@ func autoConvert_internalversion_Log_To_v1alpha1_Log(in *Log, out *v1alpha1.Log,
 	if err := v1.Convert_string_To_Pointer_string(&in.LogsFile, &out.LogsFile, s); err != nil {
 		return err
 	}
+	if err := v1.Convert_string_To_Pointer_string(&in.PreviousLogsFile, &out.PreviousLogsFile, s); err != nil {
+		return err
+	}
 	if err := v1.Convert_bool_To_Pointer_bool(&in.Follow, &out.Follow, s); err != nil {
 		return err
 	}
@@ -1947,6 +1950,9 @@ func Convert_internalversion_Log_To_v1alpha1_Log(in *Log, out *v1alpha1.Log, s c
 func autoConvert_v1alpha1_Log_To_internalversion_Log(in *v1alpha1.Log, out *Log, s conversion.Scope) error {
 	out.Containers = *(*[]string)(unsafe.Pointer(&in.Containers))
 	if err := v1.Convert_Pointer_string_To_string(&in.LogsFile, &out.LogsFile, s); err != nil {
+		return err
+	}
+	if err := v1.Convert_Pointer_string_To_string(&in.PreviousLogsFile, &out.PreviousLogsFile, s); err != nil {
 		return err
 	}
 	if err := v1.Convert_Pointer_bool_To_bool(&in.Follow, &out.Follow, s); err != nil {

--- a/pkg/apis/v1alpha1/logs_types.go
+++ b/pkg/apis/v1alpha1/logs_types.go
@@ -67,6 +67,8 @@ type Log struct {
 	Containers []string `json:"containers,omitempty"`
 	// LogsFile is the file from which the log forward starts
 	LogsFile *string `json:"logsFile,omitempty"`
+	// PreviousLogsFile is the file containing previous container logs
+	PreviousLogsFile *string `json:"previousLogsFile,omitempty"`
 	// Follow up if true
 	Follow *bool `json:"follow,omitempty"`
 }

--- a/pkg/apis/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/v1alpha1/zz_generated.deepcopy.go
@@ -1018,6 +1018,11 @@ func (in *Log) DeepCopyInto(out *Log) {
 		*out = new(string)
 		**out = **in
 	}
+	if in.PreviousLogsFile != nil {
+		in, out := &in.PreviousLogsFile, &out.PreviousLogsFile
+		*out = new(string)
+		**out = **in
+	}
 	if in.Follow != nil {
 		in, out := &in.Follow, &out.Follow
 		*out = new(bool)

--- a/pkg/kwok/server/debugging_logs.go
+++ b/pkg/kwok/server/debugging_logs.go
@@ -47,7 +47,11 @@ func (s *Server) GetContainerLogs(ctx context.Context, podName, podNamespace, co
 	}
 
 	opts := crilogs.NewLogOptions(logOptions, time.Now())
-	return readLogs(ctx, log.LogsFile, opts, stdout, stderr)
+	logsFile := log.LogsFile
+	if logOptions.Previous {
+		logsFile = log.PreviousLogsFile
+	}
+	return readLogs(ctx, logsFile, opts, stdout, stderr)
 }
 
 // getContainerLogs handles containerLogs request against the Kubelet

--- a/site/content/en/docs/generated/apis.md
+++ b/site/content/en/docs/generated/apis.md
@@ -5241,6 +5241,17 @@ string
 </tr>
 <tr>
 <td>
+<code>previousLogsFile</code>
+<em>
+string
+</em>
+</td>
+<td>
+<p>PreviousLogsFile is the file containing previous container logs</p>
+</td>
+</tr>
+<tr>
+<td>
 <code>follow</code>
 <em>
 bool

--- a/site/content/en/docs/user/logs-configuration.md
+++ b/site/content/en/docs/user/logs-configuration.md
@@ -27,9 +27,11 @@ spec:
   - containers:
     - <string>
     logsFile: <string>
+    previousLogsFile: <string>
     follow: <bool>
 ```
 The logs simulation setting of a pod is specified via `logs` field.
+The `previousLogsFile` field specifies the file path of the previous terminated container logs.
 The `logs` field is organized by groups, with each corresponding to a collection of containers that shares a same logs simulation config.
 Each group consists of a list of container names (`containers`) and the shared simulation settings (`logsFile` and `follow`).
 
@@ -61,6 +63,7 @@ spec:
   - containers:
     - <string>
     logsFile: <string>
+    previousLogsFile: <string>
     follow: <bool>
 ```
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind feature

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

- Supports configuration for terminated container logs of a pod, useful for simulating scenarios like CrashLoopBackOff.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #1335 

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Support for configuring previous container logs
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
NONE
```
