### PR TITLE
[feat] add manage pod with selector

### DIFF
--- a/charts/kwok/README.md
+++ b/charts/kwok/README.md
@@ -29,6 +29,15 @@ Set up default metrics usage policy (optional)
 helm upgrade --install kwok kwok/metrics-usage
 ```
 
+Set up default mutating webhook to manage pods with selector (optional)
+
+```shell
+CA_BUNDLE=$(kubectl get secret -n kube-system kwok-controller -o jsonpath='{.data.ca\.crt}')
+kubectl patch mutatingwebhookconfiguration kwok-controller \
+  --type='json' \
+  -p="[{'op': 'replace', 'path': '/webhooks/0/clientConfig/caBundle', 'value':'${CA_BUNDLE}'}]"
+```
+
 ## Configuration
 
 The following table lists the configurable parameters of the kwok chart and their default values.
@@ -61,3 +70,7 @@ The following table lists the configurable parameters of the kwok chart and thei
 | tolerations[1].operator | string | `"Exists"` |  |
 | volumeMounts | list | `[]` |  |
 | volumes | list | `[]` |  |
+| server.port | int | 10247 |  |
+| server.enableTLS | bool | `true` |  |
+| server.managePodsWithSelector.matchLabels | object | `{app: fake-pod}` |  |
+| server.managePodsWithSelector.excludedNamespaces | list | `{}` |  |

--- a/charts/kwok/conf/kwok.yaml
+++ b/charts/kwok/conf/kwok.yaml
@@ -8,7 +8,7 @@ options:
   nodeLeaseParallelism: 4
   podPlayStageParallelism: 4
   nodePlayStageParallelism: 4
-  nodePort: 10247
+  nodePort: {{ .Values.server.port }}
   cidr: 10.0.0.1/24
   manageAllNodes: false
   manageNodesWithAnnotationSelector: 'kwok.x-k8s.io/node=fake'

--- a/charts/kwok/conf/kwok.yaml
+++ b/charts/kwok/conf/kwok.yaml
@@ -9,6 +9,10 @@ options:
   podPlayStageParallelism: 4
   nodePlayStageParallelism: 4
   nodePort: {{ .Values.server.port }}
+  {{ if .Values.server.enableTLS }}
+  tlsCertFile: /etc/certs/tls.crt
+  tlsPrivateKeyFile: /etc/certs/tls.key
+  {{- end}}
   cidr: 10.0.0.1/24
   manageAllNodes: false
   manageNodesWithAnnotationSelector: 'kwok.x-k8s.io/node=fake'

--- a/charts/kwok/templates/deployment.yaml
+++ b/charts/kwok/templates/deployment.yaml
@@ -68,6 +68,11 @@ spec:
           subPath: kwok.yaml
           mountPath: /root/.kwok/kwok.yaml
           readOnly: true
+        {{ if .Values.server.enableTLS }}
+        - name: kwok-certs
+          mountPath: /etc/certs
+          readOnly: true
+        {{- end}}
         {{- range .Values.volumeMounts }}
         - {{- . | toYaml | nindent 10 }}
         {{- end }}
@@ -90,6 +95,11 @@ spec:
       - name: kwok-config
         configMap:
           name: {{ include "kwok.fullname" . }}
+      {{ if .Values.server.enableTLS }}
+      - name: kwok-certs
+        secret:
+          secretName: {{ include "kwok.fullname" . }}
+      {{- end}}
       {{- range .Values.volumes }}
       - {{- . | toYaml | nindent 8 }}
       {{- end }}

--- a/charts/kwok/templates/deployment.yaml
+++ b/charts/kwok/templates/deployment.yaml
@@ -40,7 +40,7 @@ spec:
           failureThreshold: 10
           httpGet:
             path: /healthz
-            port: 10247
+            port: {{ .Values.server.port }}
             scheme: HTTP
           initialDelaySeconds: 30
           periodSeconds: 60
@@ -49,7 +49,7 @@ spec:
           failureThreshold: 5
           httpGet:
             path: /healthz
-            port: 10247
+            port: {{ .Values.server.port }}
             scheme: HTTP
           initialDelaySeconds: 2
           periodSeconds: 20
@@ -58,7 +58,7 @@ spec:
           failureThreshold: 3
           httpGet:
             path: /healthz
-            port: 10247
+            port: {{ .Values.server.port }}
             scheme: HTTP
           initialDelaySeconds: 2
           periodSeconds: 10

--- a/charts/kwok/templates/kwok.yaml
+++ b/charts/kwok/templates/kwok.yaml
@@ -7,4 +7,4 @@ metadata:
     {{- include "kwok.labels" . | nindent 4 }}
 data:
   kwok.yaml: |-
-    {{- $.Files.Get "conf/kwok.yaml" | nindent 4 }}
+    {{- tpl ($.Files.Get "conf/kwok.yaml") . | nindent 4 }}

--- a/charts/kwok/templates/mutating_webhook.yaml
+++ b/charts/kwok/templates/mutating_webhook.yaml
@@ -1,0 +1,39 @@
+{{ if .Values.server.managePodsWithSelector.enabled }}
+apiVersion: admissionregistration.k8s.io/v1
+kind: MutatingWebhookConfiguration
+metadata:
+  name: {{ include "kwok.fullname" . }}
+  labels:
+    {{- include "kwok.labels" . | nindent 4 }}
+webhooks:
+  - name: kwok.{{ .Release.Namespace }}.svc
+    admissionReviewVersions: ["v1", "v1beta1"]
+    sideEffects: None
+    failurePolicy: Ignore
+    timeoutSeconds: 5
+    clientConfig:
+      service:
+        name: {{ include "kwok.fullname" . }}
+        namespace: {{ .Release.Namespace }}
+        path: "/patch/pod"
+        port: {{ .Values.server.port }}
+    rules:
+    - operations: ["CREATE"]
+      apiGroups: [""]
+      apiVersions: ["v1"]
+      resources: ["pods"]
+    objectSelector:
+      matchLabels:
+        {{- toYaml .Values.server.managePodsWithSelector.matchLabels | nindent 8 }}
+    namespaceSelector:
+      matchExpressions:
+        - key: kubernetes.io/metadata.name
+          operator: NotIn
+          values:
+            - kube-system
+          {{- if .Values.server.managePodsWithSelector.excludedNamespaces }}
+            {{- range .Values.server.managePodsWithSelector.excludedNamespaces }}
+            - {{ . }}
+            {{- end }}
+          {{- end }}
+{{ end }}

--- a/charts/kwok/templates/secret.yaml
+++ b/charts/kwok/templates/secret.yaml
@@ -1,0 +1,18 @@
+{{ if .Values.server.enableTLS }}
+{{- $altNames := list (printf "%s.%s" (include "kwok.fullname" .) .Release.Namespace) (printf "%s.%s.svc" (include "kwok.fullname" .) .Release.Namespace) "localhost" }}
+{{- $ca := genCA (include "kwok.fullname" .) 365 -}}
+{{- $cert := genSignedCert (include "kwok.fullname" .) nil $altNames 365 $ca -}}
+
+apiVersion: v1
+kind: Secret
+type: kubernetes.io/tls
+metadata:
+  name: {{ include "kwok.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "kwok.labels" . | nindent 4 }}
+data:
+  tls.crt: {{ $cert.Cert | b64enc }}
+  tls.key: {{ $cert.Key | b64enc }}
+  ca.crt: {{ $ca.Cert | b64enc }}
+{{- end}}

--- a/charts/kwok/templates/service.yaml
+++ b/charts/kwok/templates/service.yaml
@@ -7,9 +7,9 @@ metadata:
 spec:
   ports:
   - name: http
-    port: 10247
+    port: {{ .Values.server.port }}
     protocol: TCP
-    targetPort: 10247
+    targetPort: {{ .Values.server.port }}
   selector:
     {{- include "kwok.selectorLabels" . | nindent 4 }}
   type: ClusterIP

--- a/charts/kwok/values.yaml
+++ b/charts/kwok/values.yaml
@@ -48,4 +48,5 @@ volumeMounts: []
 enableDeployment: true
 server:
   port: 10247
+  enableTLS: true
 

--- a/charts/kwok/values.yaml
+++ b/charts/kwok/values.yaml
@@ -46,3 +46,6 @@ env:
       fieldPath: status.hostIP
 volumeMounts: []
 enableDeployment: true
+server:
+  port: 10247
+

--- a/charts/kwok/values.yaml
+++ b/charts/kwok/values.yaml
@@ -49,4 +49,8 @@ enableDeployment: true
 server:
   port: 10247
   enableTLS: true
-
+  managePodsWithSelector:
+    enabled: true
+    matchLabels:
+      app: fake-pod
+    excludedNamespaces: []

--- a/go.mod
+++ b/go.mod
@@ -19,6 +19,7 @@ require (
 	github.com/prometheus/client_model v0.6.2
 	github.com/spf13/cobra v1.9.1
 	github.com/spf13/pflag v1.0.6
+	github.com/stretchr/testify v1.10.0
 	github.com/wzshiming/cmux v0.4.2
 	github.com/wzshiming/ctc v1.2.3
 	github.com/wzshiming/easycel v0.6.0
@@ -105,6 +106,7 @@ require (
 	github.com/opencontainers/go-digest v1.0.0 // indirect
 	github.com/opencontainers/image-spec v1.1.0 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
+	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
 	github.com/prometheus/common v0.62.0 // indirect
 	github.com/prometheus/procfs v0.15.1 // indirect
 	github.com/russross/blackfriday/v2 v2.1.0 // indirect

--- a/pkg/kwok/cmd/root.go
+++ b/pkg/kwok/cmd/root.go
@@ -426,6 +426,8 @@ func startServer(ctx context.Context, flags *flagpole, ctr *controllers.Controll
 			svc.InstallDebuggingDisabledHandlers()
 		}
 
+		svc.InstallPatchingPodHandler()
+
 		err = svc.InstallCRD(ctx)
 		if err != nil {
 			return fmt.Errorf("failed to install crd: %w", err)

--- a/pkg/kwok/server/patching_pod.go
+++ b/pkg/kwok/server/patching_pod.go
@@ -1,0 +1,144 @@
+/*
+Copyright 2023 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package server
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+
+	admissionv1 "k8s.io/api/admission/v1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/serializer"
+
+	"sigs.k8s.io/kwok/pkg/log"
+)
+
+var (
+    universalDeserializer = serializer.NewCodecFactory(runtime.NewScheme()).UniversalDeserializer()
+)
+
+const (
+	KwokNodeLabel = "kwok.x-k8s.io/node"
+)
+
+type patchOperation struct {
+	Op    string      `json:"op"`
+	Path  string      `json:"path"`
+	Value interface{} `json:"value,omitempty"`
+}
+
+func (s *Server) handlePatchingPod(rw http.ResponseWriter, req *http.Request) {
+	logger := log.FromContext(req.Context())
+    body, err := io.ReadAll(req.Body)
+    if err != nil {
+        logger.Error("Failed to read request body", err)
+        http.Error(rw, err.Error(), http.StatusBadRequest)
+        return
+    }
+
+    var admissionReviewReq admissionv1.AdmissionReview
+    _, _, err = universalDeserializer.Decode(body, nil, &admissionReviewReq)
+    if err != nil {
+        logger.Error("Failed to decode admission review request", err)
+        http.Error(rw, err.Error(), http.StatusBadRequest)
+        return
+    }
+
+    pod := corev1.Pod{}
+    if err := json.Unmarshal(admissionReviewReq.Request.Object.Raw, &pod); err != nil {
+        logger.Error("Failed to unmarshal pod from request", err)
+        http.Error(rw, err.Error(), http.StatusBadRequest)
+        return
+    }
+
+    patches := []map[string]interface{}{}
+    nodeSelectorTerm := corev1.NodeSelectorTerm{
+        MatchExpressions: []corev1.NodeSelectorRequirement{{
+            Key:      KwokNodeLabel,
+            Operator: corev1.NodeSelectorOpExists,
+        }},
+    }
+
+    affinityPatch := map[string]interface{}{
+        "op":   "add",
+        "path": "/spec/affinity",
+        "value": corev1.Affinity{
+            NodeAffinity: &corev1.NodeAffinity{
+                RequiredDuringSchedulingIgnoredDuringExecution: &corev1.NodeSelector{
+                    NodeSelectorTerms: []corev1.NodeSelectorTerm{nodeSelectorTerm},
+                },
+            },
+        },
+    }
+
+    if pod.Spec.Affinity == nil {
+        patches = append(patches, affinityPatch)
+    }
+
+    toleration := corev1.Toleration{
+        Key:      KwokNodeLabel,
+        Operator: corev1.TolerationOpExists,
+        Effect:   corev1.TaintEffectNoSchedule,
+    }
+
+    if len(pod.Spec.Tolerations) == 0 {
+        patches = append(patches, map[string]interface{}{
+            "op":    "add",
+            "path":  "/spec/tolerations",
+            "value": []corev1.Toleration{toleration},
+        })
+    } else {
+        patches = append(patches, map[string]interface{}{
+            "op":    "add",
+            "path":  "/spec/tolerations/-",
+            "value": toleration,
+        })
+    }
+
+    patchBytes, err := json.Marshal(patches)
+    if err != nil {
+        logger.Error("Failed to marshal patches", err)
+        http.Error(rw, err.Error(), http.StatusInternalServerError)
+        return
+    }
+
+    var admissionReviewResp admissionv1.AdmissionReview
+    admissionReviewResp.Response = &admissionv1.AdmissionResponse{
+        UID:     admissionReviewReq.Request.UID,
+        Allowed: true,
+        Patch:   patchBytes,
+        PatchType: func() *admissionv1.PatchType {
+            pt := admissionv1.PatchTypeJSONPatch
+            return &pt
+        }(),
+    }
+
+    admissionReviewResp.APIVersion = "admission.k8s.io/v1"
+    admissionReviewResp.Kind = "AdmissionReview"
+
+    rw.Header().Set("Content-Type", "application/json")
+    if err := json.NewEncoder(rw).Encode(admissionReviewResp); err != nil {
+        logger.Error("Failed to encode admission response", err)
+        http.Error(rw, err.Error(), http.StatusInternalServerError)
+    }
+}
+
+func (s *Server) InstallPatchingPodHandler() {
+	s.restfulCont.Handle("/patch/pod", http.HandlerFunc(s.handlePatchingPod))
+}

--- a/pkg/kwok/server/patching_pod_test.go
+++ b/pkg/kwok/server/patching_pod_test.go
@@ -1,0 +1,270 @@
+/*
+Copyright 2023 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package server
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	admissionv1 "k8s.io/api/admission/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+)
+
+func TestHandlePatchingPod(t *testing.T) {
+	tests := []struct {
+		name           string
+		pod            *corev1.Pod
+		contentType    string
+		expectedStatus int
+		expectedPatch  bool
+		notAPod        bool
+	}{
+		{
+			name: "basic pod with no affinity or tolerations",
+			pod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-pod",
+					Namespace: "default",
+				},
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{
+							Name:  "test-container",
+							Image: "nginx",
+						},
+					},
+				},
+			},
+			contentType:    "application/json",
+			expectedStatus: http.StatusOK,
+			expectedPatch:  true,
+		},
+		{
+			name: "pod with existing node affinity but no required during scheduling",
+			pod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-pod-with-affinity",
+					Namespace: "default",
+				},
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{
+							Name:  "test-container",
+							Image: "nginx",
+						},
+					},
+					Affinity: &corev1.Affinity{
+						NodeAffinity: &corev1.NodeAffinity{
+							PreferredDuringSchedulingIgnoredDuringExecution: []corev1.PreferredSchedulingTerm{
+								{
+									Weight: 1,
+									Preference: corev1.NodeSelectorTerm{
+										MatchExpressions: []corev1.NodeSelectorRequirement{
+											{
+												Key:      "foo",
+												Operator: corev1.NodeSelectorOpIn,
+												Values:   []string{"bar"},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			contentType:    "application/json",
+			expectedStatus: http.StatusOK,
+			expectedPatch:  true,
+		},
+		{
+			name: "pod with existing tolerations",
+			pod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-pod-with-tolerations",
+					Namespace: "default",
+				},
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{
+							Name:  "test-container",
+							Image: "nginx",
+						},
+					},
+					Tolerations: []corev1.Toleration{
+						{
+							Key:      "node-role.kubernetes.io/master",
+							Operator: corev1.TolerationOpExists,
+							Effect:   corev1.TaintEffectNoSchedule,
+						},
+					},
+				},
+			},
+			contentType:    "application/json",
+			expectedStatus: http.StatusOK,
+			expectedPatch:  true,
+		},
+		{
+			name: "pod with complete node affinity",
+			pod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-pod-with-complete-affinity",
+					Namespace: "default",
+				},
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{
+							Name:  "test-container",
+							Image: "nginx",
+						},
+					},
+					Affinity: &corev1.Affinity{
+						NodeAffinity: &corev1.NodeAffinity{
+							RequiredDuringSchedulingIgnoredDuringExecution: &corev1.NodeSelector{
+								NodeSelectorTerms: []corev1.NodeSelectorTerm{
+									{
+										MatchExpressions: []corev1.NodeSelectorRequirement{
+											{
+												Key:      "foo",
+												Operator: corev1.NodeSelectorOpIn,
+												Values:   []string{"bar"},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			contentType:    "application/json",
+			expectedStatus: http.StatusOK,
+			expectedPatch:  true,
+		},
+		{
+			name: "not a pod",
+			pod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-pod",
+					Namespace: "default",
+				},
+			},
+			contentType:    "application/json",
+			expectedStatus: http.StatusOK,
+			expectedPatch:  false,
+			notAPod:        true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			server := &Server{}
+			recorder := httptest.NewRecorder()
+
+			podBytes, err := json.Marshal(tc.pod)
+			require.NoError(t, err)
+
+			kind := "Pod"
+			if tc.notAPod {
+				kind = "ConfigMap"
+			}
+
+			admissionReviewReq := admissionv1.AdmissionReview{
+				TypeMeta: metav1.TypeMeta{
+					Kind:       "AdmissionReview",
+					APIVersion: "admission.k8s.io/v1",
+				},
+				Request: &admissionv1.AdmissionRequest{
+					UID: types.UID("test-uid"),
+					Kind: metav1.GroupVersionKind{
+						Kind: kind,
+					},
+					Object: runtime.RawExtension{
+						Raw: podBytes,
+					},
+				},
+			}
+
+			reqBytes, err := json.Marshal(admissionReviewReq)
+			require.NoError(t, err)
+
+			req := httptest.NewRequest("POST", "/patch/pod", bytes.NewBuffer(reqBytes))
+			req.Header.Set("Content-Type", tc.contentType)
+			req = req.WithContext(context.Background())
+
+			server.handlePatchingPod(recorder, req)
+
+			resp := recorder.Result()
+			assert.Equal(t, tc.expectedStatus, resp.StatusCode)
+
+			if tc.expectedStatus == http.StatusOK {
+				var admissionReviewResp admissionv1.AdmissionReview
+				err = json.NewDecoder(resp.Body).Decode(&admissionReviewResp)
+				require.NoError(t, err)
+
+				assert.NotNil(t, admissionReviewResp.Response)
+				assert.Equal(t, admissionReviewReq.Request.UID, admissionReviewResp.Response.UID)
+				assert.True(t, admissionReviewResp.Response.Allowed)
+
+				if tc.expectedPatch && !tc.notAPod {
+					assert.NotNil(t, admissionReviewResp.Response.Patch)
+					assert.NotNil(t, admissionReviewResp.Response.PatchType)
+					assert.Equal(t, admissionv1.PatchTypeJSONPatch, *admissionReviewResp.Response.PatchType)
+
+					var patches []map[string]interface{}
+					err = json.Unmarshal(admissionReviewResp.Response.Patch, &patches)
+					require.NoError(t, err)
+					assert.NotEmpty(t, patches)
+
+					foundAffinity := false
+					foundToleration := false
+
+					for _, patch := range patches {
+						op, _ := patch["op"].(string)
+						path, _ := patch["path"].(string)
+
+						if op == "add" {
+							if path == "/spec/affinity" {
+								foundAffinity = true
+							}
+							if path == "/spec/tolerations" || path == "/spec/tolerations/-" {
+								foundToleration = true
+							}
+						}
+					}
+
+					if tc.pod.Spec.Affinity == nil {
+						assert.True(t, foundAffinity, "Patch should contain node affinity")
+					}
+					assert.True(t, foundToleration, "Patch should contain tolerations")
+				} else if !tc.notAPod {
+					// If it's a pod but not expecting a patch
+					assert.Empty(t, admissionReviewResp.Response.Patch)
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
#### What type of PR is this?
/kind feature

#### What this PR does / why we need it:
This pull request introduces several enhancements: including support for TLS, a new mutating webhook for pod management, and dynamic configuration options. 

### Enhancements to Pod Management and Webhook Support:
* Added a mutating webhook configuration to manage pods with specific labels and excluded namespaces. This includes a new file, `mutating_webhook.yaml`, and a webhook handler in `pkg/kwok/server/patching_pod.go` to apply node affinity and tolerations dynamically. [[1]](diffhunk://#diff-ecd492b7bef1435d5e87a32b6419fa6efa79eb20240911ff999771d7d2d371baR1-R39) [[2]](diffhunk://#diff-06b1953aef606ca0328716e864ac7e3309e1f3203ae7b0cdce8e5cc83f400637R1-R144)
* Introduced tests for the webhook handler in `patching_pod_test.go` to ensure proper functionality, including scenarios with and without affinity or tolerations.

### TLS Support:
* Added support for enabling TLS in the server, including configuration for certificate and key files in `kwok.yaml` and secret generation in `secret.yaml`. [[1]](diffhunk://#diff-9048223f2fa22e1c225c525c25d73ffefd5b27b613dc663b89c9b0b8fb235e71L11-R15) [[2]](diffhunk://#diff-216f1e086396c667bea37a06260096426808f5ffaa9ff9933a1eaa579136aa29R1-R18)
* Updated deployment and service templates to mount TLS secrets and configure ports dynamically based on `values.yaml`. [[1]](diffhunk://#diff-b31bf7e76a9e521b77ae0ea052d05c8487df78858c142b3cfa1bf96df6a86707R71-R75) [[2]](diffhunk://#diff-b31bf7e76a9e521b77ae0ea052d05c8487df78858c142b3cfa1bf96df6a86707R98-R102) [[3]](diffhunk://#diff-45db1f3aa9a3bb7bd584222591f2ba4223f4c650b1a80fcd7935551b096ab3c4L10-R12)

### Helm Chart Improvements:
* Updated `values.yaml` to include new configuration options for `server.port`, `server.enableTLS`, and `server.managePodsWithSelector`.
* Modified Helm chart templates to use dynamic values for server port and TLS settings, ensuring flexibility in deployments. [[1]](diffhunk://#diff-b31bf7e76a9e521b77ae0ea052d05c8487df78858c142b3cfa1bf96df6a86707L43-R43) [[2]](diffhunk://#diff-b31bf7e76a9e521b77ae0ea052d05c8487df78858c142b3cfa1bf96df6a86707L52-R52) [[3]](diffhunk://#diff-b31bf7e76a9e521b77ae0ea052d05c8487df78858c142b3cfa1bf96df6a86707L61-R61)

### Codebase Enhancements:
* Introduced the `InstallPatchingPodHandler` function in `root.go` to register the new webhook handler.
* Updated the Helm chart's `kwok.yaml` to use the `tpl` function for rendering dynamic values.

### Dependency Updates:
* Added `github.com/stretchr/testify` and `github.com/pmezard/go-difflib` to `go.mod` for testing and diffing support. [[1]](diffhunk://#diff-33ef32bf6c23acb95f5902d7097b7a1d5128ca061167ec0716715b0b9eeaa5f6R22) [[2]](diffhunk://#diff-33ef32bf6c23acb95f5902d7097b7a1d5128ca061167ec0716715b0b9eeaa5f6R109)

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note

```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
