### PR TITLE
doc: update Metrics doc

### DIFF
--- a/site/content/en/docs/user/metrics-configuration.md
+++ b/site/content/en/docs/user/metrics-configuration.md
@@ -17,7 +17,7 @@ The [Metrics] is a [`kwok` Configuration][configuration] that allows users to de
 The YAML below shows all the fields of a Metrics resource:
 
 ``` yaml
-kind: Metrics
+kind: Metric
 apiVersion: kwok.x-k8s.io/v1alpha1
 metadata:
   name: <string>


### PR DESCRIPTION
#### What type of PR is this?
/kind documentation

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
Doc of Metrics shows that: 
<img width="810" height="630" alt="image" src="https://github.com/user-attachments/assets/ed255adc-a9bd-4fb7-a511-5e205cc4898a" />

But when i apply like this, error occurs: 
<img width="1475" height="103" alt="image" src="https://github.com/user-attachments/assets/08660a2c-d2f8-4f61-9e70-27b9c2f05278" />

Finally, I found that it should be `Metric` instead of `Metrics`
<img width="1919" height="934" alt="image" src="https://github.com/user-attachments/assets/926d7ada-5abc-4e54-ae11-42d731701918" />

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
`None`

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
`None`
