### PR TITLE
Increase timeout in benchmark case

### DIFF
--- a/test/e2e/benchmark.go
+++ b/test/e2e/benchmark.go
@@ -217,7 +217,7 @@ func CaseBenchmark(kwokctlPath, clusterName string) *features.FeatureBuilder {
 			return ctx
 		}).
 		Assess("Delete pods", func(ctx context.Context, t *testing.T, c *envconf.Config) context.Context {
-			ctx0, cancel := context.WithTimeout(ctx, 120*time.Second)
+			ctx0, cancel := context.WithTimeout(ctx, 90*time.Second)
 			defer cancel()
 
 			err := scaleDeletePod(ctx0, t, kwokctlPath, clusterName, 10000)

--- a/test/e2e/benchmark.go
+++ b/test/e2e/benchmark.go
@@ -217,7 +217,7 @@ func CaseBenchmark(kwokctlPath, clusterName string) *features.FeatureBuilder {
 			return ctx
 		}).
 		Assess("Delete pods", func(ctx context.Context, t *testing.T, c *envconf.Config) context.Context {
-			ctx0, cancel := context.WithTimeout(ctx, 60*time.Second)
+			ctx0, cancel := context.WithTimeout(ctx, 120*time.Second)
 			defer cancel()
 
 			err := scaleDeletePod(ctx0, t, kwokctlPath, clusterName, 10000)

--- a/test/e2e/benchmark_hack.go
+++ b/test/e2e/benchmark_hack.go
@@ -166,7 +166,7 @@ func scaleCreateNodeWithHack(ctx context.Context, t *testing.T, kwokctlPath stri
 func CaseBenchmarkWithHack(kwokctlPath, clusterName string) *features.FeatureBuilder {
 	return features.New("Benchmark Hack").
 		Assess("Create nodes", func(ctx context.Context, t *testing.T, c *envconf.Config) context.Context {
-			ctx0, cancel := context.WithTimeout(ctx, 20*time.Second)
+			ctx0, cancel := context.WithTimeout(ctx, 60*time.Second)
 			defer cancel()
 
 			err := scaleCreateNodeWithHack(ctx0, t, kwokctlPath, clusterName, 5000, 100, 20)
@@ -176,7 +176,7 @@ func CaseBenchmarkWithHack(kwokctlPath, clusterName string) *features.FeatureBui
 			return ctx
 		}).
 		Assess("Create pods", func(ctx context.Context, t *testing.T, c *envconf.Config) context.Context {
-			ctx0, cancel := context.WithTimeout(ctx, 20*time.Second)
+			ctx0, cancel := context.WithTimeout(ctx, 60*time.Second)
 			defer cancel()
 
 			err := scaleCreatePodWithHack(ctx0, t, kwokctlPath, clusterName, 10000, 100, 20)
@@ -186,7 +186,7 @@ func CaseBenchmarkWithHack(kwokctlPath, clusterName string) *features.FeatureBui
 			return ctx
 		}).
 		Assess("Delete pods", func(ctx context.Context, t *testing.T, c *envconf.Config) context.Context {
-			ctx0, cancel := context.WithTimeout(ctx, 20*time.Second)
+			ctx0, cancel := context.WithTimeout(ctx, 120*time.Second)
 			defer cancel()
 
 			err := scaleDeletePodWithHack(ctx0, t, kwokctlPath, clusterName, 10000)

--- a/test/e2e/benchmark_hack.go
+++ b/test/e2e/benchmark_hack.go
@@ -166,7 +166,7 @@ func scaleCreateNodeWithHack(ctx context.Context, t *testing.T, kwokctlPath stri
 func CaseBenchmarkWithHack(kwokctlPath, clusterName string) *features.FeatureBuilder {
 	return features.New("Benchmark Hack").
 		Assess("Create nodes", func(ctx context.Context, t *testing.T, c *envconf.Config) context.Context {
-			ctx0, cancel := context.WithTimeout(ctx, 60*time.Second)
+			ctx0, cancel := context.WithTimeout(ctx, 20*time.Second)
 			defer cancel()
 
 			err := scaleCreateNodeWithHack(ctx0, t, kwokctlPath, clusterName, 5000, 100, 20)
@@ -176,7 +176,7 @@ func CaseBenchmarkWithHack(kwokctlPath, clusterName string) *features.FeatureBui
 			return ctx
 		}).
 		Assess("Create pods", func(ctx context.Context, t *testing.T, c *envconf.Config) context.Context {
-			ctx0, cancel := context.WithTimeout(ctx, 60*time.Second)
+			ctx0, cancel := context.WithTimeout(ctx, 20*time.Second)
 			defer cancel()
 
 			err := scaleCreatePodWithHack(ctx0, t, kwokctlPath, clusterName, 10000, 100, 20)
@@ -186,7 +186,7 @@ func CaseBenchmarkWithHack(kwokctlPath, clusterName string) *features.FeatureBui
 			return ctx
 		}).
 		Assess("Delete pods", func(ctx context.Context, t *testing.T, c *envconf.Config) context.Context {
-			ctx0, cancel := context.WithTimeout(ctx, 120*time.Second)
+			ctx0, cancel := context.WithTimeout(ctx, 30*time.Second)
 			defer cancel()
 
 			err := scaleDeletePodWithHack(ctx0, t, kwokctlPath, clusterName, 10000)


### PR DESCRIPTION
Fix #1436

This pull request adjusts timeout durations in benchmark test cases to improve reliability under high workloads. The changes increase the timeout values for creating and deleting nodes and pods in both standard and "hack" benchmark scenarios.

### Timeout adjustments for benchmark tests:

* [`test/e2e/benchmark.go`](diffhunk://#diff-9433aca2d6a2499b55511829069fe44703d8f16d7bf479f0c1637fbdc7107fb3L220-R220): Increased the timeout for deleting pods in the `CaseBenchmark` function from 60 seconds to 90 seconds to handle larger workloads.

* `test/e2e/benchmark_hack.go`: 
  - Increased the timeout for deleting pods in the `CaseBenchmarkWithHack` function from 20 seconds to 30 seconds.
Extend the timeout for pod deletion to ensure successful completion during benchmarks.