### PR TITLE
Add selector for pod readiness based on phase 'Pending'

### DIFF
--- a/charts/stage-fast/templates/pod-ready.yaml
+++ b/charts/stage-fast/templates/pod-ready.yaml
@@ -10,6 +10,10 @@ spec:
     matchExpressions:
     - key: '.metadata.deletionTimestamp'
       operator: 'DoesNotExist'
+    - key: '.status.phase'
+      operator: 'In'
+      values:
+      - 'Pending'
     - key: '.status.podIP'
       operator: 'DoesNotExist'
   next:

--- a/kustomize/stage/pod/fast/pod-ready.yaml
+++ b/kustomize/stage/pod/fast/pod-ready.yaml
@@ -10,6 +10,10 @@ spec:
     matchExpressions:
     - key: '.metadata.deletionTimestamp'
       operator: 'DoesNotExist'
+    - key: '.status.phase'
+      operator: 'In'
+      values:
+      - 'Pending'
     - key: '.status.podIP'
       operator: 'DoesNotExist'
   next:

--- a/kustomize/stage/pod/fast/testdata/pod-pending.input.yaml
+++ b/kustomize/stage/pod/fast/testdata/pod-pending.input.yaml
@@ -7,3 +7,5 @@ spec:
   - name: container
     image: image
   nodeName: node
+status:
+  phase: Pending

--- a/kustomize/stage/pod/general/pod-ready.yaml
+++ b/kustomize/stage/pod/general/pod-ready.yaml
@@ -10,6 +10,10 @@ spec:
     matchExpressions:
     - key: '.metadata.deletionTimestamp'
       operator: 'DoesNotExist'
+    - key: '.status.phase'
+      operator: 'In'
+      values:
+      - 'Pending'
     - key: '.status.conditions.[] | select( .type == "Initialized" ) | .status'
       operator: 'In'
       values:

--- a/pkg/kwok/controllers/pod_controller_test.go
+++ b/pkg/kwok/controllers/pod_controller_test.go
@@ -89,6 +89,9 @@ func TestPodController(t *testing.T) {
 				},
 				NodeName: "node0",
 			},
+			Status: corev1.PodStatus{
+				Phase: corev1.PodPending,
+			},
 		},
 		&corev1.Pod{
 			ObjectMeta: metav1.ObjectMeta{
@@ -104,6 +107,9 @@ func TestPodController(t *testing.T) {
 					},
 				},
 				NodeName: "xxxx",
+			},
+			Status: corev1.PodStatus{
+				Phase: corev1.PodPending,
 			},
 		},
 		&corev1.Pod{
@@ -122,6 +128,9 @@ func TestPodController(t *testing.T) {
 				},
 				NodeName: "node0",
 			},
+			Status: corev1.PodStatus{
+				Phase: corev1.PodPending,
+			},
 		},
 		&corev1.Pod{
 			ObjectMeta: metav1.ObjectMeta{
@@ -137,6 +146,9 @@ func TestPodController(t *testing.T) {
 					},
 				},
 				NodeName: "node1",
+			},
+			Status: corev1.PodStatus{
+				Phase: corev1.PodPending,
 			},
 		},
 	)
@@ -284,6 +296,9 @@ func TestPodController(t *testing.T) {
 				},
 			},
 			NodeName: "node0",
+		},
+		Status: corev1.PodStatus{
+			Phase: corev1.PodPending,
 		},
 	}, metav1.CreateOptions{})
 	if err != nil {

--- a/test/e2e/benchmark_hack.go
+++ b/test/e2e/benchmark_hack.go
@@ -53,6 +53,8 @@ spec:
   - image: busybox
     name: container-0
   nodeName: fake-node-000000
+status:
+  phase: Pending
 ---
 `
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

if a pod reaches Succeeded/Failed (terminated containers typically have no state.running.startedAt) while still retaining an Initialized=True condition (common in real kubelet behavior), this selector can re-fire and set phase: Running again, potentially breaking job completion semantics. This PR ensures job pod stays in terminal state.

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Add selector for pod readiness based on phase 'Pending'
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
