### PR TITLE
Fix flake test

### DIFF
--- a/test/kwok/kustomization.yaml
+++ b/test/kwok/kustomization.yaml
@@ -26,5 +26,3 @@ replicas:
 
 resources:
 - ../../kustomize/kwok
-- fake-deployment.yaml
-- fake-node.yaml

--- a/test/kwok/kwok.test.sh
+++ b/test/kwok/kwok.test.sh
@@ -37,6 +37,9 @@ function start_cluster() {
 
   kubectl kustomize "${DIR}" | kubectl apply -f -
   kubectl kustomize "${ROOT_DIR}/kustomize/stage/fast" | kubectl apply -f -
+  kubectl wait --for=condition=available deployment/kwok-controller -n kube-system --timeout=60s
+  kubectl apply -f "${DIR}/fake-node.yaml"
+  kubectl apply -f "${DIR}/fake-deployment.yaml"
 }
 
 # Check for normal heartbeat


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind flake
#### What this PR does / why we need it:

This is an edge case where the pod and node are created first, then kwok-controller is started, and the scheduler and kwok process the pod and node at the same time, so that when kwok fetches the pod in the node, the scheduler has just scheduled the pod, causing the pod to be ignored by kwok.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #1572


#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
NONE
```
