### PR TITLE
ci: declare contents: read on the 6 remaining workflows

### DIFF
--- a/.github/workflows/benchmark.yaml
+++ b/.github/workflows/benchmark.yaml
@@ -25,6 +25,9 @@ on:
 env:
   CGO_ENABLED: "0"
 
+permissions:
+  contents: read
+
 jobs:
   benchmark:
     runs-on: ubuntu-latest

--- a/.github/workflows/golangci-lint.yaml
+++ b/.github/workflows/golangci-lint.yaml
@@ -8,6 +8,9 @@ on:
 env:
   GOLANGCI_VERSION: "2.12.2"
 
+permissions:
+  contents: read
+
 jobs:
   golangci:
     name: lint

--- a/.github/workflows/helm-lint-test.yaml
+++ b/.github/workflows/helm-lint-test.yaml
@@ -12,6 +12,9 @@ on:
     - .ct.yaml
     - .github/workflows/helm-lint-test.yaml
 
+permissions:
+  contents: read
+
 jobs:
   lint-test:
     runs-on: ubuntu-latest

--- a/.github/workflows/test-action.yaml
+++ b/.github/workflows/test-action.yaml
@@ -15,6 +15,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: ubuntu-latest

--- a/.github/workflows/test-site.yaml
+++ b/.github/workflows/test-site.yaml
@@ -17,6 +17,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   check-site:
     runs-on: ubuntu-latest

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -32,6 +32,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   test-build:
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
Pins the default `GITHUB_TOKEN` to read-only across the six workflows still inheriting org defaults. All six are read-only CI:

- `benchmark.yaml` — go benchmarks.
- `golangci-lint.yaml` — golangci-lint matrix.
- `helm-lint-test.yaml` — chart-testing lint + test.
- `test-action.yaml` — exercises the `action.yaml` composite action.
- `test-site.yaml` — hugo site build verification.
- `test.yaml` — go test matrix.

YAML validated locally with `yaml.safe_load` on each edited file.