### PR TITLE
docs: fix stale contributor contact links

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,6 +22,8 @@ If your repo has certain guidelines for contribution, put them here ahead of the
 
 ## Contact Information
 
+- [Slack](https://kubernetes.slack.com/messages/sig-scheduling)
+- [Mailing List](https://groups.google.com/forum/#!forum/kubernetes-sig-scheduling)
 - [#kwok Slack channel](https://kubernetes.slack.com/messages/kwok/)
 - [#kwok-dev Slack channel](https://kubernetes.slack.com/messages/kwok-dev/)
 - [GitHub Discussions](https://github.com/kubernetes-sigs/kwok/discussions)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,5 +22,6 @@ If your repo has certain guidelines for contribution, put them here ahead of the
 
 ## Contact Information
 
-- [Slack](https://kubernetes.slack.com/messages/sig-scheduling)
-- [Mailing List](https://groups.google.com/forum/#!forum/kubernetes-sig-scheduling)
+- [#kwok Slack channel](https://kubernetes.slack.com/messages/kwok/)
+- [#kwok-dev Slack channel](https://kubernetes.slack.com/messages/kwok-dev/)
+- [GitHub Discussions](https://github.com/kubernetes-sigs/kwok/discussions)

--- a/site/content/en/docs/contributing/_index.md
+++ b/site/content/en/docs/contributing/_index.md
@@ -47,6 +47,7 @@ The maintainers of this project are reachable via:
 
 - The issue tracker by [filing an issue][new issue]
 - The discussion tracker by [filing a discussion][new discussion]
+- The Kubernetes [SIG-Scheduling] [Mailing List]
 - The Kubernetes [#kwok] and [#kwok-dev] Slack channels
 
 Current maintainers in [owner list], feel free to reach out directly if you have any questions!
@@ -64,6 +65,8 @@ If you're looking to contribute documentation improvements, you'll want to read 
 [new discussion]: https://github.com/kubernetes-sigs/kwok/discussions/new/choose
 [golang]: https://golang.org/doc/install
 [install docker]: https://docs.docker.com/install/#supported-platforms
+[SIG-Scheduling]: https://github.com/kubernetes/community/blob/master/sig-scheduling/README.md
+[Mailing List]: https://groups.google.com/forum/#!forum/kubernetes-sig-scheduling
 [#kwok]: https://kubernetes.slack.com/messages/kwok/
 [#kwok-dev]: https://kubernetes.slack.com/messages/kwok-dev/
 [Kubernetes Contributor Guide]: https://git.k8s.io/community/contributors/guide

--- a/site/content/en/docs/contributing/_index.md
+++ b/site/content/en/docs/contributing/_index.md
@@ -47,7 +47,7 @@ The maintainers of this project are reachable via:
 
 - The issue tracker by [filing an issue][new issue]
 - The discussion tracker by [filing a discussion][new discussion]
-- The Kubernetes [SIG-Scheduling] [Mailing List]
+- The Kubernetes [#kwok] and [#kwok-dev] Slack channels
 
 Current maintainers in [owner list], feel free to reach out directly if you have any questions!
 
@@ -64,8 +64,8 @@ If you're looking to contribute documentation improvements, you'll want to read 
 [new discussion]: https://github.com/kubernetes-sigs/kwok/discussions/new/choose
 [golang]: https://golang.org/doc/install
 [install docker]: https://docs.docker.com/install/#supported-platforms
-[SIG-Scheduling]: https://github.com/kubernetes/community/blob/master/sig-scheduling/README.md
-[Mailing List]: https://groups.google.com/forum/#!forum/kubernetes-sig-scheduling
+[#kwok]: https://kubernetes.slack.com/messages/kwok/
+[#kwok-dev]: https://kubernetes.slack.com/messages/kwok-dev/
 [Kubernetes Contributor Guide]: https://git.k8s.io/community/contributors/guide
 [Contributor Cheat Sheet]: https://git.k8s.io/community/contributors/guide/contributor-cheatsheet
 [owner list]: https://github.com/kubernetes-sigs/kwok/blob/main/OWNERS


### PR DESCRIPTION
/kind documentation

#### What type of PR is this?

kind/documentation

#### What this PR does / why we need it:

`CONTRIBUTING.md` and the site contributing page still send people to SIG Scheduling. `README.md` already points to `#kwok` and `#kwok-dev`, so new contributors can end up in the wrong place. This lines those docs up, nice and tidy.

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

Repro:
1. Open `CONTRIBUTING.md` or the contributing docs page.
2. Check the contact links.
3. Compare them with `README.md`.
4. Before this change they point to SIG Scheduling, not KWOK. Kinda confusing, and easy to hit in practice.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs
NONE
```
