### PR TITLE
fix: validate the current kubeconfig cluster before use

### DIFF
--- a/pkg/kwokctl/cmd/get/kubeconfig/kubeconfig.go
+++ b/pkg/kwokctl/cmd/get/kubeconfig/kubeconfig.go
@@ -40,6 +40,8 @@ import (
 	utilsslices "sigs.k8s.io/kwok/pkg/utils/slices"
 )
 
+var errCurrentClusterNotFound = errors.New("current cluster is not configured")
+
 type flagpole struct {
 	Name                  string
 	Host                  string
@@ -102,10 +104,9 @@ func runE(ctx context.Context, flags *flagpole) error {
 	if err != nil {
 		return fmt.Errorf("failed to minify kubeconfig file %s: %w", kubeconfigPath, err)
 	}
-	currentContext := kubeConfig.CurrentContext
 
-	clusterName := kubeConfig.Contexts[currentContext].Cluster
-	if clusterName == "" || kubeConfig.Clusters[clusterName] == nil {
+	currentContext, clusterName, err := getCurrentCluster(kubeConfig)
+	if err != nil {
 		return fmt.Errorf("failed to load kubeconfig file %s: %w", kubeconfigPath, err)
 	}
 
@@ -171,6 +172,25 @@ func runE(ctx context.Context, flags *flagpole) error {
 	}
 
 	return nil
+}
+
+func getCurrentCluster(kubeConfig *clientcmdapi.Config) (string, string, error) {
+	currentContext := kubeConfig.CurrentContext
+	context := kubeConfig.Contexts[currentContext]
+	if context == nil {
+		return "", "", errCurrentClusterNotFound
+	}
+
+	clusterName := context.Cluster
+	if clusterName == "" {
+		return "", "", errCurrentClusterNotFound
+	}
+
+	if kubeConfig.Clusters[clusterName] == nil {
+		return "", "", errCurrentClusterNotFound
+	}
+
+	return currentContext, clusterName, nil
 }
 
 func modifyAddress(origin string, address string) (string, error) {

--- a/pkg/kwokctl/cmd/get/kubeconfig/kubeconfig_test.go
+++ b/pkg/kwokctl/cmd/get/kubeconfig/kubeconfig_test.go
@@ -1,0 +1,111 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package kubeconfig
+
+import (
+	"errors"
+	"testing"
+
+	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
+)
+
+func TestGetCurrentCluster(t *testing.T) {
+	tests := []struct {
+		name               string
+		kubeConfig         *clientcmdapi.Config
+		wantCurrentContext string
+		wantClusterName    string
+		wantErr            error
+	}{
+		{
+			name: "valid current cluster",
+			kubeConfig: &clientcmdapi.Config{
+				CurrentContext: "ctx",
+				Contexts: map[string]*clientcmdapi.Context{
+					"ctx": {
+						Cluster: "cluster",
+					},
+				},
+				Clusters: map[string]*clientcmdapi.Cluster{
+					"cluster": {
+						Server: "https://127.0.0.1:6443",
+					},
+				},
+			},
+			wantCurrentContext: "ctx",
+			wantClusterName:    "cluster",
+		},
+		{
+			name: "missing current cluster name",
+			kubeConfig: &clientcmdapi.Config{
+				CurrentContext: "ctx",
+				Contexts: map[string]*clientcmdapi.Context{
+					"ctx": {},
+				},
+				Clusters: map[string]*clientcmdapi.Cluster{},
+			},
+			wantErr: errCurrentClusterNotFound,
+		},
+		{
+			name: "missing current cluster entry",
+			kubeConfig: &clientcmdapi.Config{
+				CurrentContext: "ctx",
+				Contexts: map[string]*clientcmdapi.Context{
+					"ctx": {
+						Cluster: "cluster",
+					},
+				},
+				Clusters: map[string]*clientcmdapi.Cluster{},
+			},
+			wantErr: errCurrentClusterNotFound,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotCurrentContext, gotClusterName, err := getCurrentCluster(tt.kubeConfig)
+			if !errors.Is(err, tt.wantErr) {
+				t.Fatalf("getCurrentCluster() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			if gotCurrentContext != tt.wantCurrentContext {
+				t.Fatalf("getCurrentCluster() currentContext = %q, want %q", gotCurrentContext, tt.wantCurrentContext)
+			}
+			if gotClusterName != tt.wantClusterName {
+				t.Fatalf("getCurrentCluster() clusterName = %q, want %q", gotClusterName, tt.wantClusterName)
+			}
+		})
+	}
+}
+
+func TestGetCurrentClusterAfterMinifyConfig(t *testing.T) {
+	kubeConfig := &clientcmdapi.Config{
+		CurrentContext: "ctx",
+		Contexts: map[string]*clientcmdapi.Context{
+			"ctx": {},
+		},
+		Clusters: map[string]*clientcmdapi.Cluster{},
+	}
+
+	if err := clientcmdapi.MinifyConfig(kubeConfig); err != nil {
+		t.Fatalf("MinifyConfig() error = %v", err)
+	}
+
+	_, _, err := getCurrentCluster(kubeConfig)
+	if !errors.Is(err, errCurrentClusterNotFound) {
+		t.Fatalf("getCurrentCluster() error = %v, wantErr %v", err, errCurrentClusterNotFound)
+	}
+}


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

This fixes a small but real `kwokctl get kubeconfig` edge case.
If the kubeconfig has a current context but its cluster name is empty, the command falls through and prints `failed to load kubeconfig file ...: %!w(<nil>)`. Kinda meh, and not very helpful.

This patch validates the current cluster before using it and returns a clean error instead.

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

Repro:
1. Create a cluster workdir kubeconfig where `current-context` points to a context with `cluster: ""`.
2. Run `kwokctl get kubeconfig`.
3. Before this patch it prints `%!w(<nil>)`.
4. With this patch it returns a normal validation error.

`clientcmd.LoadFromFile` accepts this file shape, and `clientcmdapi.MinifyConfig` returns nil for it, so this path is actually reachable in practice.

Tests:
- `go test ./pkg/kwokctl/cmd/get/kubeconfig`
- `go test ./pkg/kwokctl/components ./pkg/kwokctl/runtime`

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs
NONE
```
