### PR TITLE
fix: handle bracketed IPv6 hosts in kubeconfig output

### DIFF
--- a/pkg/kwokctl/cmd/get/kubeconfig/kubeconfig.go
+++ b/pkg/kwokctl/cmd/get/kubeconfig/kubeconfig.go
@@ -24,6 +24,7 @@ import (
 	"net"
 	"net/url"
 	"os"
+	"strings"
 	"time"
 
 	"github.com/spf13/cobra"
@@ -207,7 +208,11 @@ func modifyAddress(origin string, address string) (string, error) {
 		if err != nil {
 			return "", err
 		}
-		u.Host = net.JoinHostPort(address, port)
+		u.Host = net.JoinHostPort(trimIPv6Brackets(address), port)
 	}
 	return u.String(), nil
+}
+
+func trimIPv6Brackets(host string) string {
+	return strings.TrimSuffix(strings.TrimPrefix(host, "["), "]")
 }

--- a/pkg/kwokctl/cmd/get/kubeconfig/kubeconfig_test.go
+++ b/pkg/kwokctl/cmd/get/kubeconfig/kubeconfig_test.go
@@ -109,3 +109,49 @@ func TestGetCurrentClusterAfterMinifyConfig(t *testing.T) {
 		t.Fatalf("getCurrentCluster() error = %v, wantErr %v", err, errCurrentClusterNotFound)
 	}
 }
+
+func TestModifyAddress(t *testing.T) {
+	tests := []struct {
+		name    string
+		origin  string
+		address string
+		want    string
+	}{
+		{
+			name:    "hostname without port keeps original port",
+			origin:  "https://127.0.0.1:6443",
+			address: "localhost",
+			want:    "https://localhost:6443",
+		},
+		{
+			name:    "ipv6 without port keeps original port",
+			origin:  "https://127.0.0.1:6443",
+			address: "::1",
+			want:    "https://[::1]:6443",
+		},
+		{
+			name:    "bracketed ipv6 without port keeps original port",
+			origin:  "https://127.0.0.1:6443",
+			address: "[::1]",
+			want:    "https://[::1]:6443",
+		},
+		{
+			name:    "address with explicit port overrides original port",
+			origin:  "https://127.0.0.1:6443",
+			address: "[::1]:8443",
+			want:    "https://[::1]:8443",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := modifyAddress(tt.origin, tt.address)
+			if err != nil {
+				t.Fatalf("modifyAddress() error = %v", err)
+			}
+			if got != tt.want {
+				t.Fatalf("modifyAddress() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:
Tiny fix for `kwokctl get kubeconfig --host` with bracketed IPv6 hosts.

Right now `--host '[::1]'` ends up as `https://[[::1]]:6443`, so the kubeconfig is broken. This trims the brackets before `net.JoinHostPort`, keeps the old host behavior, and adds a regression test. pretty small, but real.

#### Which issue(s) this PR fixes:
Related to #1579

#### Special notes for your reviewer:
Repro:
1. `kwokctl create cluster`
2. `kwokctl get kubeconfig --host '[::1]'`
3. see `server: https://[[::1]]:6443`

After this change it stays `https://[::1]:6443`.

Checks:
- `go test ./pkg/kwokctl/cmd/get/kubeconfig -run TestModifyAddress -v`
- `go test ./...`

#### Does this PR introduce a user-facing change?
```release-note
Fix `kwokctl get kubeconfig --host` for bracketed IPv6 hosts without an explicit port.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
```docs
NONE
```
