### PR TITLE
fix: isolate TestController subtest timeouts

### DIFF
--- a/pkg/kwok/controllers/controller_test.go
+++ b/pkg/kwok/controllers/controller_test.go
@@ -222,16 +222,17 @@ func TestController(t *testing.T) {
 		},
 	}
 
-	ctx := context.Background()
-	ctx = log.NewContext(ctx, log.NewLogger(os.Stderr, log.LevelDebug))
-	ctx, cancel := context.WithTimeout(ctx, 10*time.Second)
-	t.Cleanup(func() {
-		cancel()
-		time.Sleep(time.Second)
-	})
+	baseCtx := context.Background()
+	baseCtx = log.NewContext(baseCtx, log.NewLogger(os.Stderr, log.LevelDebug))
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			ctx, cancel := context.WithTimeout(baseCtx, 10*time.Second)
+			t.Cleanup(func() {
+				cancel()
+				time.Sleep(time.Second)
+			})
+
 			ctr, err := NewController(tt.conf)
 			if (err != nil) != tt.wantErr {
 				t.Fatalf("NewController() error = %v, wantErr %v", err, tt.wantErr)


### PR DESCRIPTION
#### What type of PR is this?

/kind failing-test

#### What this PR does / why we need it:

`TestController` was sharing one 10s timeout across all subtests. So the later cases could inherit an almost-dead ctx and flake with `context deadline exceeded`.

This gives each subtest its own timeout. Small fix, but it hits a real flaky path.

#### Which issue(s) this PR fixes:

Related to #1560

#### Special notes for your reviewer:

Repro:
1. Run `go test ./pkg/kwok/controllers -run '^TestController$' -count=5` a few times, or hit `go test ./...`.
2. Before this patch I hit `TestController/node_controller_test:_manage_all_nodes_by_stream_watch` failing with `context deadline exceeded`.
3. The root cause is one shared deadline for 6 subtests.
4. After this patch each subtest gets a fresh 10s budget, so that flaky bit goes away.

Checks:
- `go test ./pkg/kwok/controllers -run '^TestController$' -count=5`
- `go test ./pkg/kwok/controllers -count=1`

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs
NONE
```
