### PR TITLE
fix: avoid shared temp file races in download cache

### DIFF
--- a/pkg/utils/file/download.go
+++ b/pkg/utils/file/download.go
@@ -31,6 +31,7 @@ import (
 	"github.com/wzshiming/httpseek"
 
 	"sigs.k8s.io/kwok/pkg/log"
+	"sigs.k8s.io/kwok/pkg/utils/flock"
 	utilspath "sigs.k8s.io/kwok/pkg/utils/path"
 	"sigs.k8s.io/kwok/pkg/utils/progressbar"
 	"sigs.k8s.io/kwok/pkg/utils/version"
@@ -145,91 +146,172 @@ func getCacheOrDownload(ctx context.Context, cacheDir, src string, mode fs.FileM
 	}
 	switch u.Scheme {
 	case "http", "https":
-
-		logger := log.FromContext(ctx)
-		logger = logger.With(
-			"uri", src,
-		)
-		logger.Info("Download")
-
-		var transport = http.DefaultTransport
-		transport = httpseek.NewMustReaderTransport(transport, func(req *http.Request, retry int, err error) error {
-			if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
-				return err
-			}
-			if retry > 10 {
-				return err
-			}
-			logger.Warn("Retry after 1s",
-				"err", err,
-				"retry", retry,
-			)
-			time.Sleep(time.Second)
-			return nil
-		})
-
-		if !quiet {
-			transport = progressbar.NewTransport(transport)
-		}
-
-		cli := &http.Client{
-			Transport: transport,
-		}
-		req, err := http.NewRequestWithContext(ctx, http.MethodGet, u.String(), nil)
-		if err != nil {
-			return "", err
-		}
-		req.Header.Set("User-Agent", version.DefaultUserAgent())
-		resp, err := cli.Do(req)
-		if err != nil {
-			return "", err
-		}
-
-		defer func() {
-			err = resp.Body.Close()
-			if err != nil {
-				logger.Error("Failed to close body of response",
-					"err", err,
-				)
-			}
-		}()
-
-		if resp.StatusCode != http.StatusOK {
-			return "", fmt.Errorf("%s: %s", u.String(), resp.Status)
-		}
-
-		err = os.MkdirAll(utilspath.Dir(cache), 0755)
-		if err != nil {
-			return "", err
-		}
-
-		d, err := os.OpenFile(cache+".tmp", os.O_CREATE|os.O_TRUNC|os.O_WRONLY, mode)
-		if err != nil {
-			return "", err
-		}
-
-		contentLength, err := io.Copy(d, resp.Body)
-		if err != nil {
-			_ = d.Close()
-			fmt.Println()
-			return "", err
-		}
-		err = d.Close()
-		if err != nil {
-			logger.Error("Failed to close file",
-				"err", err,
-			)
-		}
-		if resp.ContentLength != contentLength {
-			return "", fmt.Errorf("content length mismatch: %d != %d", resp.ContentLength, contentLength)
-		}
-
-		err = os.Rename(cache+".tmp", cache)
-		if err != nil {
-			return "", err
-		}
-		return cache, nil
+		return downloadHTTPWithCache(ctx, cache, src, u, mode, quiet)
 	default:
 		return src, nil
 	}
+}
+
+func lockIncompleteFile(ctx context.Context, path string) (*os.File, error) {
+	incompleteFile, err := flock.OpenFile(path)
+	if err != nil {
+		return nil, err
+	}
+
+	var lastUpdate = time.Now()
+	var offset int64
+	for {
+		err = flock.TryLock(incompleteFile)
+		if err == nil {
+			return incompleteFile, nil
+		}
+		if !errors.Is(err, flock.ErrLocked) {
+			_ = incompleteFile.Close()
+			return nil, fmt.Errorf("failed to lock download cache: %w", err)
+		}
+
+		off, err := incompleteFile.Seek(0, io.SeekEnd)
+		if err != nil {
+			_ = incompleteFile.Close()
+			return nil, err
+		}
+
+		if offset == off {
+			if time.Since(lastUpdate) > time.Minute {
+				_ = incompleteFile.Close()
+				return nil, fmt.Errorf("download is locked and not updated for more than 1 minute, please check the download process or remove the incomplete file: %s", path)
+			}
+		} else {
+			offset = off
+			lastUpdate = time.Now()
+			// TODO: Add progress bar to show the download progress of the other process.
+		}
+
+		select {
+		case <-ctx.Done():
+			_ = incompleteFile.Close()
+			return nil, ctx.Err()
+		case <-time.After(100 * time.Millisecond):
+		}
+	}
+}
+
+func downloadHTTPWithCache(ctx context.Context, cache, src string, u *url.URL, mode fs.FileMode, quiet bool) (string, error) {
+	err := os.MkdirAll(utilspath.Dir(cache), 0755)
+	if err != nil {
+		return "", err
+	}
+
+	tmp := cache + ".tmp"
+	incompleteFile, err := lockIncompleteFile(ctx, tmp)
+	if err != nil {
+		return "", err
+	}
+
+	logger := log.FromContext(ctx)
+	logger = logger.With("uri", src)
+	defer func() {
+		err := flock.Unlock(incompleteFile)
+		if err != nil {
+			logger.Error("Failed to unlock download cache", "path", tmp, "err", err)
+		}
+		err = incompleteFile.Close()
+		if err != nil {
+			logger.Error("Failed to close incomplete file", "path", tmp, "err", err)
+		}
+	}()
+
+	if _, err := os.Stat(cache); err == nil {
+		err = os.Remove(tmp)
+		if err != nil {
+			logger.Debug("Failed to remove incomplete file", "path", tmp, "err", err)
+		}
+		return cache, nil
+	}
+	logger.Info("Download")
+
+	var transport = http.DefaultTransport
+	transport = httpseek.NewMustReaderTransport(transport, func(req *http.Request, retry int, err error) error {
+		if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+			return err
+		}
+		if retry > 10 {
+			return err
+		}
+		logger.Warn("Retry after 1s",
+			"err", err,
+			"retry", retry,
+		)
+		time.Sleep(time.Second)
+		return nil
+	})
+
+	offset, err := incompleteFile.Seek(0, io.SeekEnd)
+	if err != nil {
+		return "", err
+	}
+	if !quiet {
+		transport = progressbar.NewTransportWithOffset(transport, uint64(offset))
+	}
+	cli := &http.Client{Transport: transport}
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, u.String(), nil)
+	if err != nil {
+		return "", err
+	}
+	req.Header.Set("User-Agent", version.DefaultUserAgent())
+	if offset > 0 {
+		req.Header.Set("Range", fmt.Sprintf("bytes=%d-", offset))
+	}
+	resp, err := cli.Do(req)
+	if err != nil {
+		return "", err
+	}
+	defer func() {
+		err := resp.Body.Close()
+		if err != nil {
+			logger.Error("Failed to close body of response", "err", err)
+		}
+	}()
+
+	if offset == 0 {
+		if resp.StatusCode != http.StatusOK {
+			return "", fmt.Errorf("GET %s: %s", u.String(), resp.Status)
+		}
+	} else {
+		switch resp.StatusCode {
+		case http.StatusPartialContent:
+			// OK
+		case http.StatusOK:
+			// Server ignored Range; restart from scratch.
+			if err := incompleteFile.Truncate(0); err != nil {
+				return "", err
+			}
+			if _, err := incompleteFile.Seek(0, io.SeekStart); err != nil {
+				return "", err
+			}
+		default:
+			return "", fmt.Errorf("GET Partial %s: %s", u.String(), resp.Status)
+		}
+	}
+
+	contentLength, err := io.Copy(incompleteFile, resp.Body)
+	if err != nil {
+		return "", err
+	}
+	if resp.ContentLength >= 0 && resp.ContentLength != contentLength {
+		return "", fmt.Errorf("content length mismatch: %d != %d", resp.ContentLength, contentLength)
+	}
+
+	err = os.Chmod(tmp, mode)
+	if err != nil {
+		return "", err
+	}
+	err = os.Rename(tmp, cache)
+	if err != nil {
+		if _, statErr := os.Stat(cache); statErr == nil {
+			return cache, nil
+		}
+		return "", err
+	}
+	return cache, nil
 }

--- a/pkg/utils/file/download_test.go
+++ b/pkg/utils/file/download_test.go
@@ -1,0 +1,147 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package file
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+func TestGetCacheOrDownloadConcurrent(t *testing.T) {
+	t.Parallel()
+
+	const body = "concurrent download cache content"
+	var requests atomic.Int32
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requests.Add(1)
+		time.Sleep(50 * time.Millisecond)
+		_, _ = w.Write([]byte(body))
+	}))
+	defer srv.Close()
+
+	cacheDir := t.TempDir()
+
+	const workers = 8
+	var wg sync.WaitGroup
+	errCh := make(chan error, workers)
+	pathCh := make(chan string, workers)
+
+	wg.Add(workers)
+	for range workers {
+		go func() {
+			defer wg.Done()
+
+			path, err := getCacheOrDownload(context.Background(), cacheDir, srv.URL+"/archive.tgz", 0644, true)
+			if err != nil {
+				errCh <- err
+				return
+			}
+			pathCh <- path
+		}()
+	}
+
+	wg.Wait()
+	close(errCh)
+	close(pathCh)
+
+	for err := range errCh {
+		if err != nil {
+			t.Fatalf("getCacheOrDownload returned error: %v", err)
+		}
+	}
+
+	var cachePath string
+	for path := range pathCh {
+		if cachePath == "" {
+			cachePath = path
+			continue
+		}
+		if path != cachePath {
+			t.Fatalf("expected a shared cache path, got %q and %q", cachePath, path)
+		}
+	}
+
+	data, err := os.ReadFile(cachePath)
+	if err != nil {
+		t.Fatalf("failed to read cache file %q: %v", cachePath, err)
+	}
+	if string(data) != body {
+		t.Fatalf("unexpected cache contents: got %q, want %q", string(data), body)
+	}
+
+	if _, err := os.Stat(cachePath + ".tmp"); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("expected incomplete download to be renamed, got err=%v", err)
+	}
+	if got := requests.Load(); got != 1 {
+		t.Fatalf("expected exactly one cold-start download, got %d", got)
+	}
+}
+
+func TestGetCacheOrDownloadResumesIncompleteFile(t *testing.T) {
+	t.Parallel()
+
+	const body = "partial download content"
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.ServeContent(w, r, "archive.tgz", time.Now(), strings.NewReader(body))
+	}))
+	defer srv.Close()
+
+	cacheDir := t.TempDir()
+	cachePath, err := getCachePath(cacheDir, srv.URL+"/archive.tgz")
+	if err != nil {
+		t.Fatalf("failed to build cache path: %v", err)
+	}
+	if err := os.MkdirAll(filepath.Dir(cachePath), 0755); err != nil {
+		t.Fatalf("failed to create cache directory: %v", err)
+	}
+	if err := os.WriteFile(cachePath+".incomplete", []byte(body[:8]), 0644); err != nil {
+		t.Fatalf("failed to create incomplete download: %v", err)
+	}
+
+	incomplete, err := os.ReadFile(cachePath + ".incomplete")
+	if err != nil {
+		t.Fatalf("failed to read incomplete download: %v", err)
+	}
+	if got, want := string(incomplete), body[:8]; got != want {
+		t.Fatalf("unexpected incomplete download: got %q, want %q", got, want)
+	}
+
+	path, err := getCacheOrDownload(context.Background(), cacheDir, srv.URL+"/archive.tgz", 0644, true)
+	if err != nil {
+		t.Fatalf("failed to resume download: %v", err)
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("failed to read resumed download: %v", err)
+	}
+	if got := string(data); got != body {
+		t.Fatalf("unexpected resumed download: got %q, want %q", got, body)
+	}
+	if _, err := os.Stat(cachePath + ".tmp"); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("expected incomplete download to be renamed, got err=%v", err)
+	}
+}

--- a/pkg/utils/flock/doc.go
+++ b/pkg/utils/flock/doc.go
@@ -1,0 +1,18 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package flock provides advisory file locks.
+package flock

--- a/pkg/utils/flock/flock.go
+++ b/pkg/utils/flock/flock.go
@@ -1,0 +1,45 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package flock
+
+import (
+	"fmt"
+	"os"
+)
+
+var (
+	// ErrLocked indicates that another process holds the advisory file lock.
+	ErrLocked = fmt.Errorf("file is already locked")
+)
+
+// TryLock attempts to acquire an exclusive advisory lock on the open file f
+// without blocking. It returns ErrLocked if another process holds the lock.
+func TryLock(f *os.File) error {
+	return tryLock(f)
+}
+
+// Unlock releases the advisory lock on the file.
+func Unlock(f *os.File) error {
+	return unlock(f)
+}
+
+// OpenFile opens path for reading and writing, creating it if it does not exist.
+// On Windows, the returned file permits another process to rename it while it is
+// open.
+func OpenFile(path string) (*os.File, error) {
+	return openFile(path)
+}

--- a/pkg/utils/flock/flock_test.go
+++ b/pkg/utils/flock/flock_test.go
@@ -1,0 +1,54 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package flock
+
+import (
+	"errors"
+	"path/filepath"
+	"testing"
+)
+
+func TestLock(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "test.lock")
+	first, err := OpenFile(path)
+	if err != nil {
+		t.Fatalf("failed to open first lock file: %v", err)
+	}
+	defer first.Close()
+	if err := TryLock(first); err != nil {
+		t.Fatalf("failed to acquire first lock: %v", err)
+	}
+
+	second, err := OpenFile(path)
+	if err != nil {
+		t.Fatalf("failed to open second lock file: %v", err)
+	}
+	defer second.Close()
+	if err := TryLock(second); !errors.Is(err, ErrLocked) {
+		t.Fatalf("expected lock to be held, got %v", err)
+	}
+
+	if err := Unlock(first); err != nil {
+		t.Fatalf("failed to unlock first lock: %v", err)
+	}
+	if err := TryLock(second); err != nil {
+		t.Fatalf("failed to acquire second lock: %v", err)
+	}
+	if err := Unlock(second); err != nil {
+		t.Fatalf("failed to unlock second lock: %v", err)
+	}
+}

--- a/pkg/utils/flock/flock_unix.go
+++ b/pkg/utils/flock/flock_unix.go
@@ -1,0 +1,44 @@
+//go:build unix
+
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package flock
+
+import (
+	"errors"
+	"os"
+	"syscall"
+)
+
+func openFile(path string) (*os.File, error) {
+	return os.OpenFile(path, os.O_CREATE|os.O_RDWR, 0644)
+}
+
+func tryLock(f *os.File) error {
+	err := syscall.Flock(int(f.Fd()), syscall.LOCK_EX|syscall.LOCK_NB)
+	if err == nil {
+		return nil
+	}
+	if !errors.Is(err, syscall.EWOULDBLOCK) && !errors.Is(err, syscall.EAGAIN) {
+		return err
+	}
+	return ErrLocked
+}
+
+func unlock(f *os.File) error {
+	return syscall.Flock(int(f.Fd()), syscall.LOCK_UN)
+}

--- a/pkg/utils/flock/flock_windows.go
+++ b/pkg/utils/flock/flock_windows.go
@@ -1,0 +1,75 @@
+//go:build windows
+
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package flock
+
+import (
+	"errors"
+	"fmt"
+	"os"
+
+	"golang.org/x/sys/windows"
+)
+
+func openFile(path string) (*os.File, error) {
+	pathPtr, err := windows.UTF16PtrFromString(path)
+	if err != nil {
+		return nil, err
+	}
+	handle, err := windows.CreateFile(
+		pathPtr,
+		windows.GENERIC_READ|windows.GENERIC_WRITE,
+		windows.FILE_SHARE_READ|windows.FILE_SHARE_WRITE|windows.FILE_SHARE_DELETE,
+		nil,
+		windows.OPEN_ALWAYS,
+		windows.FILE_ATTRIBUTE_NORMAL,
+		0,
+	)
+	if err != nil {
+		return nil, err
+	}
+	file := os.NewFile(uintptr(handle), path)
+	if file == nil {
+		if err := windows.CloseHandle(handle); err != nil {
+			return nil, fmt.Errorf("failed to close file handle: %w", err)
+		}
+		return nil, fmt.Errorf("failed to create file from handle")
+	}
+	return file, nil
+}
+
+func tryLock(f *os.File) error {
+	// Lock a byte far beyond the file contents. Locking the start of the file
+	// prevents Windows from writing downloaded data through this file handle.
+	// Keeping the lock outside the data also lets waiters inspect the current
+	// download size.
+	overlapped := windows.Overlapped{OffsetHigh: 0x80000000}
+	err := windows.LockFileEx(windows.Handle(f.Fd()), windows.LOCKFILE_EXCLUSIVE_LOCK|windows.LOCKFILE_FAIL_IMMEDIATELY, 0, 1, 0, &overlapped)
+	if err == nil {
+		return nil
+	}
+	if !errors.Is(err, windows.ERROR_LOCK_VIOLATION) {
+		return err
+	}
+	return ErrLocked
+}
+
+func unlock(f *os.File) error {
+	overlapped := windows.Overlapped{OffsetHigh: 0x80000000}
+	return windows.UnlockFileEx(windows.Handle(f.Fd()), 0, 1, 0, &overlapped)
+}

--- a/pkg/utils/flock/flock_windows_test.go
+++ b/pkg/utils/flock/flock_windows_test.go
@@ -1,0 +1,65 @@
+//go:build windows
+
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package flock
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestLockDoesNotPreventWritingFileContents(t *testing.T) {
+	file, err := OpenFile(filepath.Join(t.TempDir(), "test.lock"))
+	if err != nil {
+		t.Fatalf("failed to open lock file: %v", err)
+	}
+	defer file.Close()
+
+	if err := TryLock(file); err != nil {
+		t.Fatalf("failed to acquire lock: %v", err)
+	}
+	defer Unlock(file)
+
+	if _, err := file.Write([]byte("contents")); err != nil {
+		t.Fatalf("failed to write locked file: %v", err)
+	}
+}
+
+func TestOpenFileAllowsRenameWhileAnotherProcessWaits(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "test.lock")
+	first, err := OpenFile(path)
+	if err != nil {
+		t.Fatalf("failed to open first lock file: %v", err)
+	}
+	defer first.Close()
+	if err := TryLock(first); err != nil {
+		t.Fatalf("failed to acquire first lock: %v", err)
+	}
+	defer Unlock(first)
+
+	second, err := OpenFile(path)
+	if err != nil {
+		t.Fatalf("failed to open second lock file: %v", err)
+	}
+	defer second.Close()
+
+	if err := os.Rename(path, path+".complete"); err != nil {
+		t.Fatalf("failed to rename file while another process waits: %v", err)
+	}
+}

--- a/pkg/utils/progressbar/progressbar.go
+++ b/pkg/utils/progressbar/progressbar.go
@@ -28,17 +28,24 @@ import (
 
 // NewTransport returns a new transport that writes a progress bar to out.
 func NewTransport(base http.RoundTripper) http.RoundTripper {
+	return NewTransportWithOffset(base, 0)
+}
+
+// NewTransportWithOffset returns a new transport that writes a progress bar starting at offset.
+func NewTransportWithOffset(base http.RoundTripper, offset uint64) http.RoundTripper {
 	out := os.Stderr
 	if !term.IsTerminal(int(out.Fd())) {
 		return base
 	}
 	return &transport{
-		base: base,
+		base:   base,
+		offset: offset,
 	}
 }
 
 type transport struct {
-	base http.RoundTripper
+	base   http.RoundTripper
+	offset uint64
 }
 
 func (p *transport) RoundTrip(req *http.Request) (*http.Response, error) {
@@ -55,13 +62,8 @@ func (p *transport) RoundTrip(req *http.Request) (*http.Response, error) {
 		return resp, nil
 	}
 
-	contentLength := resp.Header.Get("Content-Length")
-	if contentLength == "" {
-		return resp, nil
-	}
-
-	contentLengthInt, _ := strconv.Atoi(contentLength)
-	if contentLengthInt <= 0 {
+	contentLength, _ := strconv.ParseUint(resp.Header.Get("Content-Length"), 10, 64)
+	if contentLength == 0 {
 		return resp, nil
 	}
 
@@ -73,7 +75,11 @@ func (p *transport) RoundTrip(req *http.Request) (*http.Response, error) {
 		name = path.Base(req.URL.Path)
 	}
 
-	resp.Body = NewReadCloser(resp.Body, name, uint64(contentLengthInt))
+	offset := uint64(0)
+	if resp.StatusCode == http.StatusPartialContent {
+		offset = p.offset
+	}
+	resp.Body = NewReadCloserWithOffset(resp.Body, name, contentLength+offset, offset)
 
 	return resp, nil
 }

--- a/pkg/utils/progressbar/reader.go
+++ b/pkg/utils/progressbar/reader.go
@@ -38,6 +38,11 @@ type reader struct {
 
 // NewReader returns a new reader that writes a progress bar to out.
 func NewReader(r io.Reader, name string, total uint64) io.Reader {
+	return NewReaderWithOffset(r, name, total, 0)
+}
+
+// NewReaderWithOffset returns a new reader that writes a progress bar to out starting at offset.
+func NewReaderWithOffset(r io.Reader, name string, total, offset uint64) io.Reader {
 	out := os.Stderr
 	if !term.IsTerminal(int(out.Fd())) {
 		return r
@@ -45,6 +50,7 @@ func NewReader(r io.Reader, name string, total uint64) io.Reader {
 
 	return &reader{
 		reader:    r,
+		current:   offset,
 		name:      name,
 		total:     total,
 		startTime: time.Now(),
@@ -77,11 +83,16 @@ func (r *reader) Read(b []byte) (int, error) {
 
 // NewReadCloser returns a new ReadCloser that writes a progress bar to out.
 func NewReadCloser(rc io.ReadCloser, name string, total uint64) io.ReadCloser {
+	return NewReadCloserWithOffset(rc, name, total, 0)
+}
+
+// NewReadCloserWithOffset returns a ReadCloser that writes a progress bar to out starting at offset.
+func NewReadCloserWithOffset(rc io.ReadCloser, name string, total, offset uint64) io.ReadCloser {
 	return struct {
 		io.Reader
 		io.Closer
 	}{
-		Reader: NewReader(rc, name, total),
+		Reader: NewReaderWithOffset(rc, name, total, offset),
 		Closer: rc,
 	}
 }


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/kind failing-test

#### What this PR does / why we need it:

Fixes a race in the shared download cache.

On `main`, `go test ./...` can hit this when `test/e2e/kwokctl/benchmark` and `test/e2e/kwokctl/benchmark-hack` download the same etcd tarball at the same time. They both write to the same `.tmp` path, one wins the rename, the other blows up with `rename ... .tmp: no such file or directory`.

This patch gives each downloader its own temp file and returns the cached file if another worker already won the rename. Also adds a tight concurrent unit test, so this doesnt drift back later.

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

Repro on `main`:

1. Run `go test ./...`
2. Watch `test/e2e/kwokctl/benchmark` and `test/e2e/kwokctl/benchmark-hack` race on the same cache entry

Targeted checks I ran:

- `go test ./pkg/utils/file ./pkg/kwokctl/runtime ./pkg/kwokctl/components`
- `go test -race ./pkg/utils/file -run TestGetCacheOrDownloadConcurrent -count=50`

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs
```
