### PR TITLE
fix: avoid panic when grouping component extra args

### DIFF
--- a/pkg/kwokctl/cmd/create/cluster/cluster.go
+++ b/pkg/kwokctl/cmd/create/cluster/cluster.go
@@ -240,7 +240,7 @@ func mutationHeartbeat(flags *flagpole) {
 func mutationComponentPatches(flags *flagpole) {
 	componentPatches := make([]internalversion.ComponentPatches, 0, len(flags.ExtraArgs))
 	componentNames := make(map[string]int)
-	for i, extraArgs := range flags.ExtraArgs {
+	for _, extraArgs := range flags.ExtraArgs {
 		splitedArgs := strings.SplitN(extraArgs, "=", 3)
 		if len(splitedArgs) != 3 {
 			continue
@@ -261,7 +261,7 @@ func mutationComponentPatches(flags *flagpole) {
 				},
 			},
 		})
-		componentNames[splitedArgs[0]] = i
+		componentNames[splitedArgs[0]] = len(componentPatches) - 1
 	}
 	flags.ComponentsPatches = append(flags.ComponentsPatches, componentPatches...)
 }

--- a/pkg/kwokctl/cmd/create/cluster/cluster_test.go
+++ b/pkg/kwokctl/cmd/create/cluster/cluster_test.go
@@ -1,0 +1,59 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cluster
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+
+	"sigs.k8s.io/kwok/pkg/apis/internalversion"
+)
+
+func TestMutationComponentPatches(t *testing.T) {
+	flags := &flagpole{
+		ExtraArgs: []string{
+			"kube-apiserver=feature-gates=A=true",
+			"kube-apiserver=audit-log-maxage=7",
+			"kube-scheduler=profiling=false",
+			"kube-scheduler=v=2",
+		},
+		KwokctlConfiguration: &internalversion.KwokctlConfiguration{},
+	}
+	want := []internalversion.ComponentPatches{
+		{
+			Name: "kube-apiserver",
+			ExtraArgs: []internalversion.ExtraArgs{
+				{Key: "feature-gates", Value: new("A=true")},
+				{Key: "audit-log-maxage", Value: new("7")},
+			},
+		},
+		{
+			Name: "kube-scheduler",
+			ExtraArgs: []internalversion.ExtraArgs{
+				{Key: "profiling", Value: new("false")},
+				{Key: "v", Value: new("2")},
+			},
+		},
+	}
+
+	mutationComponentPatches(flags)
+
+	if diff := cmp.Diff(want, flags.ComponentsPatches); diff != "" {
+		t.Errorf("mutationComponentPatches() mismatch (-want +got):\n%s", diff)
+	}
+}


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

Repeated `extra-args` for two components can panic while grouping flags. 
The map stored positions from the raw flag list, which drift after a duplicate gets grouped

This stores the grouped slice index instead and adds a regression test

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

Repro before the fix:

```console
kwokctl create cluster \
  --runtime nope \
  --extra-args kube-apiserver=a=1 \
  --extra-args kube-apiserver=b=2 \
  --extra-args kube-scheduler=c=3 \
  --extra-args kube-scheduler=d=4
```

This panics with `index out of range [2] with length 2` before runtime lookup. 
Pretty easy to hit with real component configs

#### Does this PR introduce a user-facing change?

```release-note
Fixed a kwokctl panic when multiple components each have repeated extra arguments.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs
NONE
```
