### PR TITLE
[kwokctl] Self-heal exited components while waiting for cluster ready

### DIFF
--- a/pkg/kwokctl/runtime/binary/cluster_status.go
+++ b/pkg/kwokctl/runtime/binary/cluster_status.go
@@ -63,6 +63,14 @@ func (c *Cluster) WaitReady(ctx context.Context, timeout time.Duration) error {
 				"err", err,
 			)
 		}
+		if !ready {
+			// Self-heal: startComponent no-ops running components, so this only restarts exited ones.
+			if err := c.startComponents(ctx); err != nil {
+				logger.Debug("Failed to restart components",
+					"err", err,
+				)
+			}
+		}
 		return ready, nil
 	},
 		wait.WithTimeout(timeout),

--- a/pkg/utils/exec/cmd_windows.go
+++ b/pkg/utils/exec/cmd_windows.go
@@ -21,7 +21,6 @@ package exec
 import (
 	"context"
 	"fmt"
-	"os"
 	"os/exec"
 	"syscall"
 
@@ -45,8 +44,20 @@ func command(ctx context.Context, name string, arg ...string) *exec.Cmd {
 }
 
 func isRunning(pid int) bool {
-	_, err := os.FindProcess(pid)
-	return err == nil
+	// os.FindProcess also succeeds for exited processes whose object is kept
+	// alive by an open handle, so check the handle's signaled state instead.
+	handle, err := windows.OpenProcess(windows.SYNCHRONIZE, false, uint32(pid))
+	if err != nil {
+		return false
+	}
+	defer func() {
+		_ = windows.CloseHandle(handle)
+	}()
+	event, err := windows.WaitForSingleObject(handle, 0)
+	if err != nil {
+		return false
+	}
+	return event == uint32(windows.WAIT_TIMEOUT)
 }
 
 func setUser(cmd *exec.Cmd, uid, gid *int64) error {

--- a/pkg/utils/exec/exec.go
+++ b/pkg/utils/exec/exec.go
@@ -243,6 +243,13 @@ func Command(ctx context.Context, name string, args ...string) (cmd *Cmd, err er
 		return nil, fmt.Errorf("cmd start: %s %s: %w", name, strings.Join(args, " "), err)
 	}
 
+	if opt.Fork && !opt.Wait {
+		// Reap the child if it exits, otherwise the zombie keeps its pid alive and masks liveness checks.
+		go func() {
+			_ = cmd.Wait()
+		}()
+	}
+
 	if opt.Wait {
 		err = cmd.Wait()
 		if err != nil {

--- a/test/e2e/attach.go
+++ b/test/e2e/attach.go
@@ -19,6 +19,7 @@ package e2e
 import (
 	"bytes"
 	"context"
+	"errors"
 	"os"
 	"strings"
 	"testing"
@@ -68,8 +69,9 @@ func CaseAttach(kwokctlPath, clusterName, nodeName, namespace, tmpDir string) *f
 				t.Fatal(err)
 			}
 			defer func() {
+				// The reaper in exec.Command may have already reaped a child that exited on its own.
 				err = cmd.Process.Kill()
-				if err != nil {
+				if err != nil && !errors.Is(err, os.ErrProcessDone) {
 					t.Fatal(err)
 				}
 			}()

--- a/test/e2e/kwokctl_port_forward.go
+++ b/test/e2e/kwokctl_port_forward.go
@@ -18,8 +18,10 @@ package e2e
 
 import (
 	"context"
+	"errors"
 	"io"
 	"net/http"
+	"os"
 	"testing"
 	"time"
 
@@ -41,8 +43,9 @@ func CaseKwokctlPortForward(kwokctlPath, clusterName string) *features.FeatureBu
 			}
 
 			defer func() {
+				// The reaper in exec.Command may have already reaped a child that exited on its own.
 				err = cmd.Process.Kill()
-				if err != nil {
+				if err != nil && !errors.Is(err, os.ErrProcessDone) {
 					t.Fatal(err)
 				}
 			}()

--- a/test/e2e/logs.go
+++ b/test/e2e/logs.go
@@ -19,6 +19,7 @@ package e2e
 import (
 	"bytes"
 	"context"
+	"errors"
 	"os"
 	"testing"
 	"time"
@@ -67,8 +68,9 @@ func CaseLogs(kwokctlPath, clusterName, nodeName, namespace, tmpDir string) *fea
 				t.Fatal(err)
 			}
 			defer func() {
+				// The reaper in exec.Command may have already reaped a child that exited on its own.
 				err = cmd.Process.Kill()
-				if err != nil {
+				if err != nil && !errors.Is(err, os.ErrProcessDone) {
 					t.Fatal(err)
 				}
 			}()

--- a/test/e2e/port_forward.go
+++ b/test/e2e/port_forward.go
@@ -18,8 +18,10 @@ package e2e
 
 import (
 	"context"
+	"errors"
 	"io"
 	"net/http"
+	"os"
 	"testing"
 	"time"
 
@@ -53,8 +55,9 @@ func CasePortForward(kwokctlPath, clusterName, nodeName, namespace string) *feat
 			}
 
 			defer func() {
+				// The reaper in exec.Command may have already reaped a child that exited on its own.
 				err = cmd.Process.Kill()
-				if err != nil {
+				if err != nil && !errors.Is(err, os.ErrProcessDone) {
 					t.Fatal(err)
 				}
 			}()

--- a/test/e2e/recording.go
+++ b/test/e2e/recording.go
@@ -183,7 +183,12 @@ func CaseRecording(kwokctlPath, clusterName string, tmpDir string) *features.Fea
 		Assess("delete pod0", helper.DeletePod(pod0)).
 		Assess("delete pod1", helper.DeletePod(pod1)).
 		Assess("delete node0", helper.DeleteNode(node0)).
-		Assess("delete node1", helper.DeleteNode(node1))
+		Assess("delete node1", helper.DeleteNode(node1)).
+		WithTeardown("cleanup recording file", func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
+			// "snapshot export" refuses to overwrite an existing file, so a leftover recording would break the next case.
+			_ = os.Remove(recordingPath)
+			return ctx
+		})
 }
 
 // CaseRecordingExternal is the recording of a test case.
@@ -336,5 +341,10 @@ func CaseRecordingExternal(kwokctlPath, clusterName string, tmpDir string) *feat
 		Assess("delete pod0", helper.DeletePod(pod0)).
 		Assess("delete pod1", helper.DeletePod(pod1)).
 		Assess("delete node0", helper.DeleteNode(node0)).
-		Assess("delete node1", helper.DeleteNode(node1))
+		Assess("delete node1", helper.DeleteNode(node1)).
+		WithTeardown("cleanup recording file", func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
+			// "snapshot export" refuses to overwrite an existing file, so a leftover recording would break the next case.
+			_ = os.Remove(recordingPath)
+			return ctx
+		})
 }


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/kind flake

#### What this PR does / why we need it:

A component that exits right after starting is never restarted, so `kwokctl create cluster --wait` burns the whole timeout at N-1/N ready. This is what happened to metrics-server in the windows/binary e2e job: the process died after the first start and nothing brought it back until `TestRestart` incidentally resurrected it.

`WaitReady` (binary runtime) now re-runs `startComponents` on each poll while the cluster is not ready; `startComponent` already no-ops components that are still running. `Ready()`/`InspectComponent` stay side-effect-free since they are also used by `kwokctl get clusters`.

Verified locally (darwin, binary runtime): `kill -9` kube-controller-manager during `create cluster --wait 90s` → component restarted with a new pid, cluster truly `5/5 Ready` in ~4s instead of burning the timeout.

#### Which issue(s) this PR fixes:

Fixes #1741

#### Special notes for your reviewer:

Stacked on #1743 (its commits show up here until it merges): the self-heal relies on `IsRunning` truthfully reporting exited components, which #1743 fixes. Review only the `[kwokctl] Self-heal…` commit here.

#### Does this PR introduce a user-facing change?

```release-note
kwokctl: components that exit while waiting for the cluster to be ready are now restarted automatically.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs

```
