### PR TITLE
[kwokctl] Fix liveness detection of exited forked processes

### DIFF
--- a/pkg/utils/exec/cmd_windows.go
+++ b/pkg/utils/exec/cmd_windows.go
@@ -21,7 +21,6 @@ package exec
 import (
 	"context"
 	"fmt"
-	"os"
 	"os/exec"
 	"syscall"
 
@@ -45,8 +44,20 @@ func command(ctx context.Context, name string, arg ...string) *exec.Cmd {
 }
 
 func isRunning(pid int) bool {
-	_, err := os.FindProcess(pid)
-	return err == nil
+	// os.FindProcess also succeeds for exited processes whose object is kept
+	// alive by an open handle, so check the handle's signaled state instead.
+	handle, err := windows.OpenProcess(windows.SYNCHRONIZE, false, uint32(pid))
+	if err != nil {
+		return false
+	}
+	defer func() {
+		_ = windows.CloseHandle(handle)
+	}()
+	event, err := windows.WaitForSingleObject(handle, 0)
+	if err != nil {
+		return false
+	}
+	return event == uint32(windows.WAIT_TIMEOUT)
 }
 
 func setUser(cmd *exec.Cmd, uid, gid *int64) error {

--- a/pkg/utils/exec/exec.go
+++ b/pkg/utils/exec/exec.go
@@ -243,6 +243,13 @@ func Command(ctx context.Context, name string, args ...string) (cmd *Cmd, err er
 		return nil, fmt.Errorf("cmd start: %s %s: %w", name, strings.Join(args, " "), err)
 	}
 
+	if opt.Fork && !opt.Wait {
+		// Reap the child if it exits, otherwise the zombie keeps its pid alive and masks liveness checks.
+		go func() {
+			_ = cmd.Wait()
+		}()
+	}
+
 	if opt.Wait {
 		err = cmd.Wait()
 		if err != nil {

--- a/test/e2e/attach.go
+++ b/test/e2e/attach.go
@@ -19,6 +19,7 @@ package e2e
 import (
 	"bytes"
 	"context"
+	"errors"
 	"os"
 	"strings"
 	"testing"
@@ -68,8 +69,9 @@ func CaseAttach(kwokctlPath, clusterName, nodeName, namespace, tmpDir string) *f
 				t.Fatal(err)
 			}
 			defer func() {
+				// The reaper in exec.Command may have already reaped a child that exited on its own.
 				err = cmd.Process.Kill()
-				if err != nil {
+				if err != nil && !errors.Is(err, os.ErrProcessDone) {
 					t.Fatal(err)
 				}
 			}()

--- a/test/e2e/kwokctl_port_forward.go
+++ b/test/e2e/kwokctl_port_forward.go
@@ -18,8 +18,10 @@ package e2e
 
 import (
 	"context"
+	"errors"
 	"io"
 	"net/http"
+	"os"
 	"testing"
 	"time"
 
@@ -41,8 +43,9 @@ func CaseKwokctlPortForward(kwokctlPath, clusterName string) *features.FeatureBu
 			}
 
 			defer func() {
+				// The reaper in exec.Command may have already reaped a child that exited on its own.
 				err = cmd.Process.Kill()
-				if err != nil {
+				if err != nil && !errors.Is(err, os.ErrProcessDone) {
 					t.Fatal(err)
 				}
 			}()

--- a/test/e2e/logs.go
+++ b/test/e2e/logs.go
@@ -19,6 +19,7 @@ package e2e
 import (
 	"bytes"
 	"context"
+	"errors"
 	"os"
 	"testing"
 	"time"
@@ -67,8 +68,9 @@ func CaseLogs(kwokctlPath, clusterName, nodeName, namespace, tmpDir string) *fea
 				t.Fatal(err)
 			}
 			defer func() {
+				// The reaper in exec.Command may have already reaped a child that exited on its own.
 				err = cmd.Process.Kill()
-				if err != nil {
+				if err != nil && !errors.Is(err, os.ErrProcessDone) {
 					t.Fatal(err)
 				}
 			}()

--- a/test/e2e/port_forward.go
+++ b/test/e2e/port_forward.go
@@ -18,8 +18,10 @@ package e2e
 
 import (
 	"context"
+	"errors"
 	"io"
 	"net/http"
+	"os"
 	"testing"
 	"time"
 
@@ -53,8 +55,9 @@ func CasePortForward(kwokctlPath, clusterName, nodeName, namespace string) *feat
 			}
 
 			defer func() {
+				// The reaper in exec.Command may have already reaped a child that exited on its own.
 				err = cmd.Process.Kill()
-				if err != nil {
+				if err != nil && !errors.Is(err, os.ErrProcessDone) {
 					t.Fatal(err)
 				}
 			}()

--- a/test/e2e/recording.go
+++ b/test/e2e/recording.go
@@ -183,7 +183,12 @@ func CaseRecording(kwokctlPath, clusterName string, tmpDir string) *features.Fea
 		Assess("delete pod0", helper.DeletePod(pod0)).
 		Assess("delete pod1", helper.DeletePod(pod1)).
 		Assess("delete node0", helper.DeleteNode(node0)).
-		Assess("delete node1", helper.DeleteNode(node1))
+		Assess("delete node1", helper.DeleteNode(node1)).
+		WithTeardown("cleanup recording file", func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
+			// "snapshot export" refuses to overwrite an existing file, so a leftover recording would break the next case.
+			_ = os.Remove(recordingPath)
+			return ctx
+		})
 }
 
 // CaseRecordingExternal is the recording of a test case.
@@ -336,5 +341,10 @@ func CaseRecordingExternal(kwokctlPath, clusterName string, tmpDir string) *feat
 		Assess("delete pod0", helper.DeletePod(pod0)).
 		Assess("delete pod1", helper.DeletePod(pod1)).
 		Assess("delete node0", helper.DeleteNode(node0)).
-		Assess("delete node1", helper.DeleteNode(node1))
+		Assess("delete node1", helper.DeleteNode(node1)).
+		WithTeardown("cleanup recording file", func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
+			// "snapshot export" refuses to overwrite an existing file, so a leftover recording would break the next case.
+			_ = os.Remove(recordingPath)
+			return ctx
+		})
 }


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

`Command` never waits on forked children, so a component that exits while kwokctl is still running becomes a zombie on unix. The signal-0 liveness check (`IsRunning`) then keeps reporting it alive for the parent's whole lifetime: `kwokctl create cluster --wait` counts a dead component as ready and returns false-green. Once kwokctl exits the zombie is reparented and reaped, so a later `kwokctl get clusters` suddenly shows the component NotReady — the lie is only visible inside the process that forked it, which is exactly the `--wait` window.

On windows the same misdetection has a different mechanism: `os.FindProcess` succeeds for exited processes while any handle is still open, so detection depended on GC finalizer timing.

Changes:

- **Reap forked children (unix)**: a goroutine calls `cmd.Wait()` for forked processes, so exited children are reaped immediately and `IsRunning` reflects reality.
- **Deterministic liveness on windows**: `isRunning` now checks the process handle's signaled state via `OpenProcess(SYNCHRONIZE)` + `WaitForSingleObject(0)` instead of `os.FindProcess`.
- **E2e adaptation**: cases that fork and later kill a process tolerate `os.ErrProcessDone`, since a child that exits on its own is already reaped by the time the deferred `Kill` runs.
- **E2e recording cleanup** (second commit): reaping exposed a latent defect — both recording cases write to the same `recording.yaml`, and `snapshot export` refuses to overwrite it, so the external recorder exited immediately; signaling that zombie still silently "succeeded", letting `finish record` pass without recording anything (this is what the first CI round of this PR caught). The recording file is now removed in a teardown, which runs even when an assessment fails, so each case starts clean.

Verified on darwin: killing a component during `create cluster --wait` is now honestly reported as NotReady instead of false-green, and no zombies are left behind; `GOOS=windows` build and vet pass.

#### Which issue(s) this PR fixes:

Part of #1741: this fixes the liveness misdetection that masked the dead component; the wait-loop self-heal that actually recovers it is stacked on top in #1742.

#### Special notes for your reviewer:

- The reap goroutine is guarded by `opt.Fork && !opt.Wait`, so it cannot race the `opt.Wait` path's `cmd.Wait`; `KillProcess` already tolerates `ErrProcessDone`/`ECHILD`, so concurrent reaping is safe on both sides.
- Behavior note: on unix a component that dies during `--wait` previously made the wait return false-green; with this fix the wait honestly reports NotReady (and burns the timeout) until #1742 adds the self-heal.

#### Does this PR introduce a user-facing change?

```release-note
kwokctl: fixed liveness detection of components that exited while kwokctl is still running (unix zombie children, windows handle-held processes); a dead component is no longer counted as ready.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs

```
