### PR TITLE
[kwokctl] Reject invalid kind feature gate values

### DIFF
--- a/pkg/kwokctl/runtime/kind/kind.go
+++ b/pkg/kwokctl/runtime/kind/kind.go
@@ -451,11 +451,14 @@ func buildKindConfigV1alpha4(conf BuildKindConfig) (*kindv1alpha4.Cluster, error
 	featureGates := map[string]bool{}
 	for _, fg := range conf.FeatureGates {
 		kv := strings.SplitN(fg, "=", 2)
-		if len(kv) == 2 {
-			featureGates[kv[0]], _ = strconv.ParseBool(kv[1])
-		} else {
+		if len(kv) != 2 {
 			return nil, fmt.Errorf("invalid feature gate: %s", fg)
 		}
+		v, err := strconv.ParseBool(kv[1])
+		if err != nil {
+			return nil, fmt.Errorf("invalid feature gate: %s: %w", fg, err)
+		}
+		featureGates[kv[0]] = v
 	}
 
 	runtimeConfig := map[string]string{}

--- a/pkg/kwokctl/runtime/kind/kind_test.go
+++ b/pkg/kwokctl/runtime/kind/kind_test.go
@@ -1,0 +1,85 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package kind
+
+import (
+	"reflect"
+	"strings"
+	"testing"
+)
+
+func Test_buildKindConfigV1alpha4_FeatureGates(t *testing.T) {
+	tests := []struct {
+		name         string
+		featureGates []string
+		want         map[string]bool
+		wantErr      bool
+	}{
+		{
+			name:         "normal valid values",
+			featureGates: []string{"Foo=true", "Bar=false"},
+			want:         map[string]bool{"Foo": true, "Bar": false},
+		},
+		{
+			name:         "valid alternate strconv.ParseBool values",
+			featureGates: []string{"Foo=T", "Bar=0"},
+			want:         map[string]bool{"Foo": true, "Bar": false},
+		},
+		{
+			name:         "missing equals",
+			featureGates: []string{"Foo"},
+			wantErr:      true,
+		},
+		{
+			name:         "empty value",
+			featureGates: []string{"Foo="},
+			wantErr:      true,
+		},
+		{
+			name:         "invalid value",
+			featureGates: []string{"Foo=ture"},
+			wantErr:      true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := buildKindConfigV1alpha4(BuildKindConfig{FeatureGates: tt.featureGates})
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("buildKindConfigV1alpha4() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			if tt.wantErr {
+				return
+			}
+			if !reflect.DeepEqual(got.FeatureGates, tt.want) {
+				t.Errorf("buildKindConfigV1alpha4() FeatureGates = %v, want %v", got.FeatureGates, tt.want)
+			}
+		})
+	}
+}
+
+func Test_buildKindConfigV1alpha4_FeatureGates_InvalidValueError(t *testing.T) {
+	_, err := buildKindConfigV1alpha4(BuildKindConfig{FeatureGates: []string{"Foo=ture"}})
+	if err == nil {
+		t.Fatal("buildKindConfigV1alpha4() error = nil, want error")
+	}
+	if !strings.Contains(err.Error(), "invalid feature gate") {
+		t.Errorf("buildKindConfigV1alpha4() error = %q, want it to contain %q", err.Error(), "invalid feature gate")
+	}
+	if !strings.Contains(err.Error(), "Foo=ture") {
+		t.Errorf("buildKindConfigV1alpha4() error = %q, want it to contain %q", err.Error(), "Foo=ture")
+	}
+}


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

The kind runtime converts `--kube-feature-gates` values to `map[string]bool` using `strconv.ParseBool`.

Previously, the parse error was discarded, so invalid values such as `Foo=ture` or `Foo=` were silently treated as `false`.

This change returns an error for invalid boolean values instead, while preserving all boolean formats accepted by `strconv.ParseBool`.

Regression tests cover valid values, alternate valid boolean formats, missing `=`, empty values, invalid values, and error reporting.

#### Which issue(s) this PR fixes:

Fixes #1739

#### Special notes for your reviewer:

Validation completed locally:

* `go test ./pkg/kwokctl/runtime/kind/... -v`
* `go test ./pkg/...`
* `make unit-test`
* `git diff --check`

The regression test was also verified red-before-green: with the production change removed, the tests fail because `Foo=` and `Foo=ture` return no error; with the fix restored, they pass.

#### Does this PR introduce a user-facing change?

```release-note
[kwokctl] Reject invalid boolean feature-gate values for the kind runtime instead of silently treating them as false.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs
NONE
```
