### PR TITLE
[kwokctl] Keep binary port-forward alive after dial failure

### DIFF
--- a/pkg/kwokctl/runtime/binary/cluster_port_forward.go
+++ b/pkg/kwokctl/runtime/binary/cluster_port_forward.go
@@ -79,7 +79,7 @@ func (c *Cluster) PortForward(ctx context.Context, name string, portOrName strin
 					"err", err,
 					"port", targetPort,
 				)
-				return
+				continue
 			}
 			go func() {
 				defer func() {

--- a/pkg/kwokctl/runtime/binary/cluster_port_forward_test.go
+++ b/pkg/kwokctl/runtime/binary/cluster_port_forward_test.go
@@ -1,0 +1,139 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package binary
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net"
+	"strconv"
+	"testing"
+	"time"
+
+	"sigs.k8s.io/kwok/pkg/kwokctl/runtime"
+)
+
+// pickUnusedPort asks the OS for an ephemeral TCP port and releases it
+// immediately so the caller can reuse the port number.
+func pickUnusedPort(t *testing.T) uint32 {
+	t.Helper()
+	listener, err := net.Listen("tcp", ":0")
+	if err != nil {
+		t.Fatalf("failed to allocate an unused port: %v", err)
+	}
+	port := listener.Addr().(*net.TCPAddr).Port
+	if err := listener.Close(); err != nil {
+		t.Fatalf("failed to release allocated port: %v", err)
+	}
+	return uint32(port)
+}
+
+// TestPortForwardRecoversAfterFailedTargetDial is a regression test for
+// https://github.com/kubernetes-sigs/kwok/issues/1740: a single failed dial
+// to the target port used to terminate the whole accept loop, permanently
+// killing the port-forward while the listening socket stayed open.
+func TestPortForwardRecoversAfterFailedTargetDial(t *testing.T) {
+	ctx, cancelCtx := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancelCtx()
+
+	hostPort := pickUnusedPort(t)
+	targetPort := pickUnusedPort(t)
+	for targetPort == hostPort {
+		targetPort = pickUnusedPort(t)
+	}
+	// nothing listens on targetPort yet
+
+	c := &Cluster{
+		Cluster: runtime.NewCluster("test", t.TempDir()),
+	}
+
+	cancel, err := c.PortForward(ctx, "test-component", strconv.FormatUint(uint64(targetPort), 10), hostPort)
+	if err != nil {
+		t.Fatalf("PortForward returned error: %v", err)
+	}
+	defer cancel()
+
+	fwdAddr := fmt.Sprintf("127.0.0.1:%d", hostPort)
+
+	// Step 1: connect once while nothing listens on targetPort, forcing the
+	// internal dial to the target to fail.
+	conn1, err := net.DialTimeout("tcp", fwdAddr, 5*time.Second)
+	if err != nil {
+		t.Fatalf("failed to dial forwarding port: %v", err)
+	}
+	defer func() { _ = conn1.Close() }()
+
+	// Step 2: deterministically prove the failed dial has already been
+	// processed. Both the buggy and fixed implementations close this first
+	// connection immediately after the target dial fails (only what happens
+	// to the accept loop afterward differs), so observing the close here -
+	// bounded by a deadline instead of an arbitrary sleep - is a reliable,
+	// version-independent synchronization point.
+	if err := conn1.SetReadDeadline(time.Now().Add(5 * time.Second)); err != nil {
+		t.Fatalf("failed to set read deadline: %v", err)
+	}
+	buf := make([]byte, 1)
+	if _, err := conn1.Read(buf); err == nil {
+		t.Fatalf("expected connection to be closed after failed target dial, but read succeeded")
+	}
+	_ = conn1.Close()
+
+	// Step 3: bring the target up and prove the SAME PortForward instance
+	// can still serve a new connection.
+	targetLn, err := net.Listen("tcp", fmt.Sprintf(":%d", targetPort))
+	if err != nil {
+		t.Fatalf("failed to start target listener: %v", err)
+	}
+	defer func() { _ = targetLn.Close() }()
+
+	go func() {
+		conn, err := targetLn.Accept()
+		if err != nil {
+			return
+		}
+		defer func() { _ = conn.Close() }()
+		_, _ = io.Copy(conn, conn) // echo
+	}()
+
+	conn2, err := net.DialTimeout("tcp", fwdAddr, 5*time.Second)
+	if err != nil {
+		t.Fatalf("failed to dial forwarding port a second time: %v", err)
+	}
+	defer func() { _ = conn2.Close() }()
+
+	if err := conn2.SetDeadline(time.Now().Add(5 * time.Second)); err != nil {
+		t.Fatalf("failed to set deadline: %v", err)
+	}
+
+	// merely establishing conn2 is not sufficient proof of recovery: on the
+	// buggy implementation the kernel listen backlog can still complete a
+	// TCP handshake even though nothing calls Accept anymore. Actual data
+	// must flow end-to-end through the forward.
+	const payload = "ping"
+	if _, err := conn2.Write([]byte(payload)); err != nil {
+		t.Fatalf("failed to write to forwarded connection: %v", err)
+	}
+
+	resp := make([]byte, len(payload))
+	if _, err := io.ReadFull(conn2, resp); err != nil {
+		t.Fatalf("failed to read echoed data through recovered PortForward: %v", err)
+	}
+	if string(resp) != payload {
+		t.Fatalf("unexpected echoed data: got %q, want %q", resp, payload)
+	}
+}

--- a/pkg/kwokctl/runtime/binary/cluster_port_forward_test.go
+++ b/pkg/kwokctl/runtime/binary/cluster_port_forward_test.go
@@ -18,6 +18,7 @@ package binary
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"net"
@@ -26,22 +27,9 @@ import (
 	"time"
 
 	"sigs.k8s.io/kwok/pkg/kwokctl/runtime"
+	utilsnet "sigs.k8s.io/kwok/pkg/utils/net"
+	"sigs.k8s.io/kwok/pkg/utils/sets"
 )
-
-// pickUnusedPort asks the OS for an ephemeral TCP port and releases it
-// immediately so the caller can reuse the port number.
-func pickUnusedPort(t *testing.T) uint32 {
-	t.Helper()
-	listener, err := net.Listen("tcp", ":0")
-	if err != nil {
-		t.Fatalf("failed to allocate an unused port: %v", err)
-	}
-	port := listener.Addr().(*net.TCPAddr).Port
-	if err := listener.Close(); err != nil {
-		t.Fatalf("failed to release allocated port: %v", err)
-	}
-	return uint32(port)
-}
 
 // TestPortForwardRecoversAfterFailedTargetDial is a regression test for
 // https://github.com/kubernetes-sigs/kwok/issues/1740: a single failed dial
@@ -51,10 +39,9 @@ func TestPortForwardRecoversAfterFailedTargetDial(t *testing.T) {
 	ctx, cancelCtx := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancelCtx()
 
-	// Step 1: reserve targetPort by opening a real listener and immediately
-	// closing it. Closing before PortForward starts is what guarantees the
-	// FIRST dial to targetPort fails, reproducing #1740; targetLn is reused
-	// below once the target comes up on this same port number.
+	// Step 1: reserve a target port, then close the listener so the first
+	// internal target dial fails. The listener cannot remain open because TCP
+	// connection establishment does not require the application to call Accept.
 	targetLn, err := net.Listen("tcp", ":0")
 	if err != nil {
 		t.Fatalf("failed to allocate target port: %v", err)
@@ -64,11 +51,11 @@ func TestPortForwardRecoversAfterFailedTargetDial(t *testing.T) {
 		t.Fatalf("failed to release target port: %v", err)
 	}
 
-	hostPort := pickUnusedPort(t)
-	for hostPort == targetPort {
-		hostPort = pickUnusedPort(t)
+	// hostPort must differ from targetPort.
+	hostPort, err := utilsnet.GetUnusedPort(ctx, sets.NewSets(targetPort))
+	if err != nil {
+		t.Fatalf("failed to allocate host port: %v", err)
 	}
-	// nothing listens on targetPort yet
 
 	c := &Cluster{
 		Cluster: runtime.NewCluster("test", t.TempDir()),
@@ -82,7 +69,7 @@ func TestPortForwardRecoversAfterFailedTargetDial(t *testing.T) {
 
 	fwdAddr := fmt.Sprintf("127.0.0.1:%d", hostPort)
 
-	// Step 1: connect once while nothing listens on targetPort, forcing the
+	// Step 2: connect once while nothing listens on targetPort, forcing the
 	// internal dial to the target to fail.
 	conn1, err := net.DialTimeout("tcp", fwdAddr, 5*time.Second)
 	if err != nil {
@@ -90,23 +77,25 @@ func TestPortForwardRecoversAfterFailedTargetDial(t *testing.T) {
 	}
 	defer func() { _ = conn1.Close() }()
 
-	// Step 2: deterministically prove the failed dial has already been
-	// processed. Both the buggy and fixed implementations close this first
-	// connection immediately after the target dial fails (only what happens
-	// to the accept loop afterward differs), so observing the close here -
-	// bounded by a deadline instead of an arbitrary sleep - is a reliable,
-	// version-independent synchronization point.
+	// Step 3: wait until PortForward processes the failed target dial and closes
+	// conn1. A timeout only proves our deadline expired, so require a non-timeout
+	// read error before starting the target listener.
 	if err := conn1.SetReadDeadline(time.Now().Add(5 * time.Second)); err != nil {
 		t.Fatalf("failed to set read deadline: %v", err)
 	}
 	buf := make([]byte, 1)
-	if _, err := conn1.Read(buf); err == nil {
+	_, readErr := conn1.Read(buf)
+	if readErr == nil {
 		t.Fatalf("expected connection to be closed after failed target dial, but read succeeded")
+	}
+	var netErr net.Error
+	if errors.As(readErr, &netErr) && netErr.Timeout() {
+		t.Fatalf("timed out waiting for PortForward to close conn1 after the failed target dial: %v", readErr)
 	}
 	_ = conn1.Close()
 
-	// Step 3: bring the target up and prove the SAME PortForward instance
-	// can still serve a new connection.
+	// Step 4: bring the target up on the same port and prove the same
+	// PortForward instance can still serve a new connection.
 	targetLn, err = net.Listen("tcp", fmt.Sprintf(":%d", targetPort))
 	if err != nil {
 		t.Fatalf("failed to start target listener: %v", err)

--- a/pkg/kwokctl/runtime/binary/cluster_port_forward_test.go
+++ b/pkg/kwokctl/runtime/binary/cluster_port_forward_test.go
@@ -51,10 +51,22 @@ func TestPortForwardRecoversAfterFailedTargetDial(t *testing.T) {
 	ctx, cancelCtx := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancelCtx()
 
+	// Step 1: reserve targetPort by opening a real listener and immediately
+	// closing it. Closing before PortForward starts is what guarantees the
+	// FIRST dial to targetPort fails, reproducing #1740; targetLn is reused
+	// below once the target comes up on this same port number.
+	targetLn, err := net.Listen("tcp", ":0")
+	if err != nil {
+		t.Fatalf("failed to allocate target port: %v", err)
+	}
+	targetPort := uint32(targetLn.Addr().(*net.TCPAddr).Port)
+	if err := targetLn.Close(); err != nil {
+		t.Fatalf("failed to release target port: %v", err)
+	}
+
 	hostPort := pickUnusedPort(t)
-	targetPort := pickUnusedPort(t)
-	for targetPort == hostPort {
-		targetPort = pickUnusedPort(t)
+	for hostPort == targetPort {
+		hostPort = pickUnusedPort(t)
 	}
 	// nothing listens on targetPort yet
 
@@ -95,7 +107,7 @@ func TestPortForwardRecoversAfterFailedTargetDial(t *testing.T) {
 
 	// Step 3: bring the target up and prove the SAME PortForward instance
 	// can still serve a new connection.
-	targetLn, err := net.Listen("tcp", fmt.Sprintf(":%d", targetPort))
+	targetLn, err = net.Listen("tcp", fmt.Sprintf(":%d", targetPort))
 	if err != nil {
 		t.Fatalf("failed to start target listener: %v", err)
 	}


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

The binary runtime's port-forward accept loop stopped serving after a single failed connection to the target port.

When the target component was temporarily unavailable, the failed `net.Dial` closed the client connection and returned from the entire accept loop. The forwarding listener remained open, but subsequent connections were no longer accepted or forwarded.

This change keeps the accept loop running after a target dial failure so the same port-forward can recover when the target becomes available again.

A regression test verifies that:

* the initial connection fails while the target is unavailable
* the target is then started
* a second connection through the same port-forward successfully sends and receives data

#### Which issue(s) this PR fixes:

Fixes #1740

#### Special notes for your reviewer:

Validation completed locally:

* `go test -race -v -run TestPortForwardRecoversAfterFailedTargetDial -count=10 ./pkg/kwokctl/runtime/binary/...`
* `go test -race ./pkg/...`
* `git diff --check`

The regression test was also verified red-before-green. With the original `return`, the second connection times out because the accept loop has exited. With the change to `continue`, the same port-forward successfully recovers and forwards data.

#### Does this PR introduce a user-facing change?

```release-note
[kwokctl] Binary runtime port-forward now recovers after transient target connection failures.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs
NONE
```
