### PR TITLE
fix: avoid goroutine leak in net.Tunnel

### DIFF
--- a/pkg/utils/net/tunnel.go
+++ b/pkg/utils/net/tunnel.go
@@ -24,7 +24,11 @@ import (
 
 // Tunnel create tunnels for two streams.
 func Tunnel(ctx context.Context, c1, c2 io.ReadWriter, buf1, buf2 []byte) error {
-	errCh := make(chan error)
+	// Buffered so that both senders can complete even when this function
+	// returns without receiving their results, which the two ctx.Done() paths
+	// below do. On an unbuffered channel those goroutines block on the send
+	// forever once the caller closes the streams.
+	errCh := make(chan error, 2)
 	go func() {
 		_, err := io.CopyBuffer(c2, c1, buf1)
 		errCh <- err

--- a/pkg/utils/net/tunnel_test.go
+++ b/pkg/utils/net/tunnel_test.go
@@ -1,0 +1,128 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package net
+
+import (
+	"context"
+	"io"
+	"runtime"
+	"testing"
+	"time"
+)
+
+// blockedStream is an io.ReadWriter whose Read blocks until unblock is called,
+// which keeps a Tunnel copy goroutine in flight while the test cancels the
+// context. It stands in for the network connections the real callers pass.
+type blockedStream struct {
+	r *io.PipeReader
+	w *io.PipeWriter
+}
+
+func newBlockedStream() *blockedStream {
+	r, w := io.Pipe()
+	return &blockedStream{r: r, w: w}
+}
+
+func (s *blockedStream) Read(p []byte) (int, error) {
+	return s.r.Read(p)
+}
+
+func (s *blockedStream) Write(p []byte) (int, error) {
+	return s.w.Write(p)
+}
+
+// unblock releases a Read that is currently blocked, the way closing the
+// underlying connection does.
+func (s *blockedStream) unblock() {
+	_ = s.r.Close()
+}
+
+// waitForGoroutines waits for the goroutine count to fall back to baseline.
+// A leaked Tunnel copy goroutine is parked on a channel send and never exits,
+// so it keeps the count above baseline until the deadline.
+func waitForGoroutines(t *testing.T, baseline int, timeout time.Duration) {
+	t.Helper()
+
+	deadline := time.Now().Add(timeout)
+	for {
+		if n := runtime.NumGoroutine(); n <= baseline {
+			return
+		} else if time.Now().After(deadline) {
+			t.Fatalf("goroutines did not return to baseline: got %d, want <= %d", n, baseline)
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+}
+
+// runTunnel starts Tunnel in the background and returns a channel closed once
+// it has returned.
+func runTunnel(ctx context.Context, c1, c2 io.ReadWriter) <-chan struct{} {
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		_ = Tunnel(ctx, c1, c2, make([]byte, 32), make([]byte, 32))
+	}()
+	return done
+}
+
+func TestTunnelDoesNotLeakWhenCanceledBeforeEitherCopyFinishes(t *testing.T) {
+	c1 := newBlockedStream()
+	c2 := newBlockedStream()
+
+	baseline := runtime.NumGoroutine()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	done := runTunnel(ctx, c1, c2)
+
+	// Give both copies time to reach their blocking Read before canceling, so
+	// that Tunnel returns through the outer ctx.Done() path.
+	time.Sleep(50 * time.Millisecond)
+	cancel()
+	<-done
+
+	// Callers close the streams after Tunnel returns. That releases the copies,
+	// and each one then reports its result on the error channel.
+	c1.unblock()
+	c2.unblock()
+
+	waitForGoroutines(t, baseline, 3*time.Second)
+}
+
+func TestTunnelDoesNotLeakWhenCanceledAfterTheFirstCopyFinishes(t *testing.T) {
+	c1 := newBlockedStream()
+	c2 := newBlockedStream()
+
+	// The c1 -> c2 copy ends immediately; the c2 -> c1 copy stays blocked, so
+	// Tunnel receives one result and then returns through the inner
+	// ctx.Done() path with the second still pending.
+	c1.unblock()
+
+	baseline := runtime.NumGoroutine()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	done := runTunnel(ctx, c1, c2)
+
+	time.Sleep(50 * time.Millisecond)
+	cancel()
+	<-done
+
+	c2.unblock()
+
+	waitForGoroutines(t, baseline, 3*time.Second)
+}


### PR DESCRIPTION
/kind bug

#### What this PR does / why we need it:

`Tunnel` starts two copy goroutines that report their result on an unbuffered
channel, and it has two paths that return without receiving both results: the
context being canceled before either copy finishes, and the context being
canceled after the first result arrives. Once the caller closes the streams,
the pending `io.CopyBuffer` calls return and each goroutine that still has a
result to deliver blocks on the send forever.

kwok is long running, so up to two goroutines leaked for every exec or
port-forward session a client interrupted, along with the buffers they hold.
Buffering the channel lets both senders complete so the goroutines can exit.

#### Which issue(s) this PR fixes:

Fixes #1737

#### Special notes for your reviewer:

The two tests cover the two return paths named in the issue. Both fail against
the current code, and the goroutine counts differ in the way you would expect:
the outer-cancel test leaks 2, the inner-cancel test leaks 1 because the first
result was already consumed.

Verified locally: `make unit-test` (race detector, 25 packages) passes, and
`hack/verify-{go-lint,go-format,spelling,boilerplate,ends-newline,go-mod}.sh`
all pass.

I also mentioned a separate observation on the issue: at the call sites in
`debugging_port_forword.go` and `debugging_exec_other.go`, the `defer` that
returns the buffers to `s.bufPool` is registered after the `defer` that closes
the connection, so LIFO returns the buffers to the shared pool while the copy
goroutines may still be using them. That is not addressed here since it cannot
be fixed inside `Tunnel` (waiting for the copies would deadlock, as they only
finish once the caller closes the streams). Happy to open a separate issue.

#### Does this PR introduce a user-facing change?

```release-note
Fixed a goroutine leak in `kubectl exec` and `kubectl port-forward` sessions that are interrupted by the client.
```
