### PR TITLE
fix: handle kubeconfig path lists

### DIFF
--- a/pkg/utils/kubeconfig/kubeconfig.go
+++ b/pkg/utils/kubeconfig/kubeconfig.go
@@ -27,22 +27,11 @@ import (
 	"k8s.io/client-go/tools/clientcmd"
 	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
 	clientcmdlatest "k8s.io/client-go/tools/clientcmd/api/latest"
-
-	"sigs.k8s.io/kwok/pkg/utils/envs"
-	utilspath "sigs.k8s.io/kwok/pkg/utils/path"
-)
-
-const (
-	recommendedConfigPathEnvVar = "KUBECONFIG"
-	recommendedHomeDir          = ".kube"
-	recommendedFileName         = "config"
 )
 
 // GetRecommendedKubeconfigPath returns the recommended config file based on the current environment
 func GetRecommendedKubeconfigPath() string {
-	defaultPath := utilspath.Join(envs.GetEnv("HOME", ""), recommendedHomeDir, recommendedFileName)
-	defaultPath = envs.GetEnv(recommendedConfigPathEnvVar, defaultPath)
-	return defaultPath
+	return clientcmd.NewDefaultClientConfigLoadingRules().GetDefaultFilename()
 }
 
 // Config is a struct that contains the information needed to create a kubeconfig file

--- a/pkg/utils/kubeconfig/kubeconfig_test.go
+++ b/pkg/utils/kubeconfig/kubeconfig_test.go
@@ -18,6 +18,8 @@ package kubeconfig
 
 import (
 	"os"
+	"path/filepath"
+	"strings"
 	"testing"
 
 	"k8s.io/client-go/tools/clientcmd"
@@ -25,11 +27,41 @@ import (
 )
 
 func TestGetRecommendedKubeconfigPath(t *testing.T) {
-	gotKubeconfigPath := GetRecommendedKubeconfigPath()
-	wantKubeconfigPath := clientcmd.NewDefaultClientConfigLoadingRules().GetDefaultFilename()
-	if gotKubeconfigPath != wantKubeconfigPath {
-		t.Errorf("got %q, want %q", gotKubeconfigPath, wantKubeconfigPath)
-	}
+	t.Run("default", func(t *testing.T) {
+		t.Setenv(clientcmd.RecommendedConfigPathEnvVar, "")
+
+		gotKubeconfigPath := GetRecommendedKubeconfigPath()
+		wantKubeconfigPath := clientcmd.NewDefaultClientConfigLoadingRules().GetDefaultFilename()
+		if gotKubeconfigPath != wantKubeconfigPath {
+			t.Errorf("got %q, want %q", gotKubeconfigPath, wantKubeconfigPath)
+		}
+	})
+
+	t.Run("path list", func(t *testing.T) {
+		dir := t.TempDir()
+		firstPath := filepath.Join(dir, "first")
+		secondPath := filepath.Join(dir, "second")
+		if err := os.WriteFile(firstPath, nil, 0644); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(secondPath, nil, 0644); err != nil {
+			t.Fatal(err)
+		}
+		t.Setenv(clientcmd.RecommendedConfigPathEnvVar, strings.Join([]string{firstPath, secondPath}, string(os.PathListSeparator)))
+
+		gotKubeconfigPath := GetRecommendedKubeconfigPath()
+		if gotKubeconfigPath != firstPath {
+			t.Errorf("got %q, want %q", gotKubeconfigPath, firstPath)
+		}
+
+		if err := os.Remove(firstPath); err != nil {
+			t.Fatal(err)
+		}
+		gotKubeconfigPath = GetRecommendedKubeconfigPath()
+		if gotKubeconfigPath != secondPath {
+			t.Errorf("got %q, want %q", gotKubeconfigPath, secondPath)
+		}
+	})
 }
 
 var testKubeconfig = `apiVersion: v1


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

KUBECONFIG can contain multiple files, but kwokctl treated the whole list as one filename. 
This uses the client-go loading rules to pick the first existing file

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

Repro before the fix:

```bash
touch /tmp/first /tmp/second
export KUBECONFIG=/tmp/first:/tmp/second
kwokctl create cluster
```

The context target becomes the literal `/tmp/first:/tmp/second` path

Tests: `make unit-test` and `./hack/verify-go-lint.sh`

#### Does this PR introduce a user-facing change?

```release-note
Fix kubeconfig updates when KUBECONFIG contains multiple files.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs
NONE
```
