### PR TITLE
[chart] Add namespace to kwok chart namespaced templates

### DIFF
--- a/charts/kwok/templates/deployment.yaml
+++ b/charts/kwok/templates/deployment.yaml
@@ -3,6 +3,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ include "kwok.fullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "kwok.labels" . | nindent 4 }}
 spec:

--- a/charts/kwok/templates/kwok.yaml
+++ b/charts/kwok/templates/kwok.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ include "kwok.fullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "kwok.labels" . | nindent 4 }}
 data:

--- a/charts/kwok/templates/service.yaml
+++ b/charts/kwok/templates/service.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "kwok.fullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "kwok.labels" . | nindent 4 }}
 spec:


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

`helm template kwok charts/kwok --namespace kube-system` renders the Deployment, Service and ConfigMap without `metadata.namespace`; only the ServiceAccount and the RBAC subjects have it. Those three templates are hand-written and not covered by `hack/update-helm-charts.sh` (it only syncs the rbac/stage/metrics files and rewrites `kube-system` there), so they never picked up the namespace that `kustomize build kustomize/kwok` already emits via the kustomization's top-level `namespace`.

This adds `namespace: {{ .Release.Namespace }}` to the three templates, same as `service_account.yaml`. `helm install` output is unchanged; it only matters for `helm template` consumers that apply the manifests themselves.

#### Which issue(s) this PR fixes:

NONE

#### Special notes for your reviewer:

`hack/verify-helm-charts.sh` and `helm lint charts/kwok` pass locally. Didn't bump `Chart.yaml`, following the usual "Bump charts to x.y.z" release commits.

#### Does this PR introduce a user-facing change?

```release-note
Set `metadata.namespace` on the Deployment, Service and ConfigMap of the `kwok` Helm chart so `helm template` output is complete.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs

```
