### PR TITLE
[kwokctl] Fix context in cluster creation hint

### DIFF
--- a/pkg/kwokctl/cmd/create/cluster/cluster.go
+++ b/pkg/kwokctl/cmd/create/cluster/cluster.go
@@ -20,6 +20,7 @@ package cluster
 import (
 	"context"
 	"fmt"
+	"io"
 	"os"
 	"slices"
 	"strings"
@@ -457,12 +458,16 @@ func runE(ctx context.Context, flags *flagpole) error {
 	}
 
 	if log.IsTerminal() && flags.Kubeconfig != "" && !rt.IsDryRun() {
-		_, _ = fmt.Fprintf(os.Stderr, `You can now use your cluster with:
+		printClusterInfoHint(os.Stderr, name)
+	}
+	return nil
+}
+
+func printClusterInfoHint(w io.Writer, name string) {
+	_, _ = fmt.Fprintf(w, `You can now use your cluster with:
 
 	kubectl cluster-info --context %s
 
 Thanks for using kwok!
-`, name)
-	}
-	return nil
+`, config.ClusterName(name))
 }

--- a/pkg/kwokctl/cmd/create/cluster/cluster_test.go
+++ b/pkg/kwokctl/cmd/create/cluster/cluster_test.go
@@ -17,12 +17,28 @@ limitations under the License.
 package cluster
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
 
 	"sigs.k8s.io/kwok/pkg/apis/internalversion"
 )
+
+func TestPrintClusterInfoHint(t *testing.T) {
+	var out strings.Builder
+	printClusterInfoHint(&out, "example")
+
+	want := `You can now use your cluster with:
+
+	kubectl cluster-info --context kwok-example
+
+Thanks for using kwok!
+`
+	if got := out.String(); got != want {
+		t.Fatalf("printClusterInfoHint() = %q, want %q", got, want)
+	}
+}
 
 func TestMutationComponentPatches(t *testing.T) {
 	flags := &flagpole{


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/kind regression

#### What this PR does / why we need it:

`kwokctl create cluster --name demo` writes context `kwok-demo` but suggests `demo`. 
Print the correct context and add a regression test

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

Repro: create a named cluster, then run the printed `kubectl cluster-info` command. 
On `main` it fails because the suggested context does not exist

Tests: `go test ./pkg/...`, `make verify`, and a Docker cluster end to end

#### Does this PR introduce a user-facing change?

```release-note
Fix the kubeconfig context shown after creating a cluster.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs
NONE
```
