### PR TITLE
[kwokctl] Return scale deletion errors

### DIFF
--- a/pkg/kwokctl/scale/scale.go
+++ b/pkg/kwokctl/scale/scale.go
@@ -20,6 +20,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"sort"
@@ -140,6 +141,15 @@ func Scale(ctx context.Context, clientset client.Clientset, conf Config) error {
 		return ri.List(ctx, opts)
 	})
 	deleteCount := 0
+	var deleteErrors []error
+	deleteResource := func(name string) {
+		err := ri.Delete(ctx, name, metav1.DeleteOptions{})
+		if err != nil {
+			deleteErrors = append(deleteErrors, fmt.Errorf("failed to delete resource %q: %w", name, err))
+			return
+		}
+		deleteCount++
+	}
 	objs := make([]softInfo, 0, conf.Replicas)
 	sorted := false
 	err = listPager.EachListItem(ctx, metav1.ListOptions{
@@ -166,15 +176,8 @@ func Scale(ctx context.Context, clientset client.Clientset, conf Config) error {
 			sorted = true
 		}
 
-		deleteCount++
-
 		if len(objs) == 0 {
-			err = ri.Delete(ctx, obj.GetName(), metav1.DeleteOptions{})
-			if err != nil {
-				logger.Error("Delete resource",
-					"err", err,
-				)
-			}
+			deleteResource(obj.GetName())
 			return nil
 		}
 
@@ -182,22 +185,12 @@ func Scale(ctx context.Context, clientset client.Clientset, conf Config) error {
 		endObj := objs[len(objs)-1]
 		if endObj.Less(obj.GetCreationTimestamp(), obj.GetName()) {
 			// Delete the last object.
-			err = ri.Delete(ctx, obj.GetName(), metav1.DeleteOptions{})
-			if err != nil {
-				logger.Error("Delete resource",
-					"err", err,
-				)
-			}
+			deleteResource(obj.GetName())
 			return nil
 		}
 
 		// Delete the end object.
-		err = ri.Delete(ctx, endObj.Name, metav1.DeleteOptions{})
-		if err != nil {
-			logger.Error("Delete resource",
-				"err", err,
-			)
-		}
+		deleteResource(endObj.Name)
 
 		// Find the index of the new object to be inserted.
 		index, _ := sort.Find(len(objs), func(i int) int {
@@ -209,12 +202,7 @@ func Scale(ctx context.Context, clientset client.Clientset, conf Config) error {
 
 		if index == len(objs) {
 			// Delete the last object.
-			err = ri.Delete(ctx, obj.GetName(), metav1.DeleteOptions{})
-			if err != nil {
-				logger.Error("Delete resource",
-					"err", err,
-				)
-			}
+			deleteResource(obj.GetName())
 			return nil
 		}
 		// Insert the new object.
@@ -234,6 +222,11 @@ func Scale(ctx context.Context, clientset client.Clientset, conf Config) error {
 			"counter", deleteCount,
 			"elapsed", time.Since(start),
 		)
+	}
+	if err := errors.Join(deleteErrors...); err != nil {
+		return err
+	}
+	if deleteCount > 0 {
 		return nil
 	}
 

--- a/pkg/kwokctl/scale/scale_test.go
+++ b/pkg/kwokctl/scale/scale_test.go
@@ -1,0 +1,118 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package scale
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/dynamic"
+	dynamicfake "k8s.io/client-go/dynamic/fake"
+	k8stesting "k8s.io/client-go/testing"
+
+	"sigs.k8s.io/kwok/pkg/utils/client"
+)
+
+func TestScaleReturnsDeleteErrorsAndContinues(t *testing.T) {
+	gvr := schema.GroupVersionResource{Version: "v1", Resource: "nodes"}
+
+	nodes := []runtime.Object{
+		newScaledNode("test-000000"),
+		newScaledNode("test-000001"),
+	}
+	dynamicClient := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(
+		runtime.NewScheme(),
+		map[schema.GroupVersionResource]string{gvr: "NodeList"},
+		nodes...,
+	)
+
+	var attempted []string
+	dynamicClient.PrependReactor("delete", "nodes", func(action k8stesting.Action) (bool, runtime.Object, error) {
+		name := action.(k8stesting.DeleteAction).GetName()
+		attempted = append(attempted, name)
+		if name == "test-000000" {
+			return true, nil, apierrors.NewForbidden(gvr.GroupResource(), name, errors.New("deletion denied"))
+		}
+		return false, nil, nil
+	})
+
+	err := Scale(context.Background(), &testClientset{
+		dynamicClient: dynamicClient,
+		mapper:        &testRESTMapper{gvr: gvr},
+	}, Config{
+		Template:     "apiVersion: v1\nkind: Node\nmetadata: {}\n",
+		Name:         "test",
+		Replicas:     0,
+		SerialLength: 6,
+	})
+	if err == nil || !strings.Contains(err.Error(), "deletion denied") {
+		t.Fatalf("Scale() error = %v, want deletion error", err)
+	}
+	if len(attempted) != 2 {
+		t.Fatalf("attempted deletes = %v, want both nodes", attempted)
+	}
+	if _, err := dynamicClient.Resource(gvr).Get(context.Background(), "test-000000", metav1.GetOptions{}); err != nil {
+		t.Fatalf("denied node was removed: %v", err)
+	}
+	if _, err := dynamicClient.Resource(gvr).Get(context.Background(), "test-000001", metav1.GetOptions{}); !apierrors.IsNotFound(err) {
+		t.Fatalf("allowed node still exists: %v", err)
+	}
+}
+
+func newScaledNode(name string) *unstructured.Unstructured {
+	return &unstructured.Unstructured{Object: map[string]any{
+		"apiVersion": "v1",
+		"kind":       "Node",
+		"metadata": map[string]any{
+			"name": name,
+			"labels": map[string]any{
+				labelNameKey: "test",
+			},
+		},
+	}}
+}
+
+type testClientset struct {
+	client.Clientset
+	dynamicClient dynamic.Interface
+	mapper        meta.RESTMapper
+}
+
+type testRESTMapper struct {
+	meta.RESTMapper
+	gvr schema.GroupVersionResource
+}
+
+func (m *testRESTMapper) ResourceFor(schema.GroupVersionResource) (schema.GroupVersionResource, error) {
+	return m.gvr, nil
+}
+
+func (c *testClientset) ToDynamicClient() (dynamic.Interface, error) {
+	return c.dynamicClient, nil
+}
+
+func (c *testClientset) ToRESTMapper() (meta.RESTMapper, error) {
+	return c.mapper, nil
+}


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

`kwokctl scale` swallowed DELETE failures, logged `Deleted resources`, and exited 0 while objects remained. 
Tiny footgun

Keep processing the batch, count successful deletes, then return all API errors

Repro:

```bash
kwokctl scale node denied-node --replicas 1
kubectl apply -f - <<'EOF'
apiVersion: v1
kind: List
items:
- apiVersion: admissionregistration.k8s.io/v1
  kind: ValidatingAdmissionPolicy
  metadata:
    name: deny-node-delete
  spec:
    matchConstraints:
      resourceRules:
      - apiGroups: [""]
        apiVersions: ["v1"]
        operations: ["DELETE"]
        resources: ["nodes"]
    validations:
    - expression: "false"
      message: "node deletion denied"
- apiVersion: admissionregistration.k8s.io/v1
  kind: ValidatingAdmissionPolicyBinding
  metadata:
    name: deny-node-delete
  spec:
    policyName: deny-node-delete
    validationActions: [Deny]
EOF
kwokctl scale node denied-node --replicas 0
echo $?
```

Before this exits 0. 
With this change it exits 1 and reports the denial, as expected

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

Tested with `go test -race ./pkg/kwokctl/scale`, `go test ./pkg/...`, and `make verify`.

#### Does this PR introduce a user-facing change?

```release-note
`kwokctl scale` now returns an error when a resource cannot be deleted during scale down.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs
NONE
```
